### PR TITLE
Implement `--dry-run` mode.

### DIFF
--- a/lib/cucumber/core.rb
+++ b/lib/cucumber/core.rb
@@ -24,8 +24,8 @@ module Cucumber
       self
     end
 
-    def execute(gherkin_documents, mappings, report, filters = [])
-      receiver = Test::Runner.new(report)
+    def execute(gherkin_documents, mappings, report, filters = [], run_options = {})
+      receiver = Test::Runner.new(report, run_options)
       filters << [Test::HookCompiler, [mappings]]
       filters << [Test::Mapper, [mappings]]
       compile gherkin_documents, receiver, filters

--- a/spec/cucumber/core/test/runner_spec.rb
+++ b/spec/cucumber/core/test/runner_spec.rb
@@ -172,4 +172,94 @@ module Cucumber::Core::Test
 
   end
 
+  describe 'with the dry run strategy'  do
+
+    let(:report) { double(:report).as_null_object }
+    let(:source) { double(:source) }
+    let(:runner) { Runner.new(report, :run_mode => :dry_run) }
+    let(:passing) { Step.new([double]).map {} }
+    let(:undefined) { Step.new([double]) }
+    let(:test_case) { Case.new(test_steps, source) }
+
+    context 'with a passing step' do
+      let(:test_steps) { [passing] }
+
+      it 'reports the test case as skipped' do
+        report.should_receive(:after_test_case) do |test_case, result|
+          result.should be_skipped
+        end
+        test_case.describe_to runner
+      end
+
+      it 'reports the test step has been skipped' do
+        report.should_receive(:after_test_step) do |test_step, result|
+          result.should be_skipped
+        end
+        test_case.describe_to runner
+      end
+    end
+
+    context 'with a undefined step' do
+      let(:test_steps) { [undefined] }
+
+      it 'reports the test case as undefined' do
+        report.should_receive(:after_test_case) do |test_case, result|
+          result.should be_undefined
+        end
+        test_case.describe_to runner
+      end
+
+
+      it 'reports the test step as undefined' do
+        report.should_receive(:after_test_step) do |test_step, result|
+          result.should be_undefined
+        end
+        test_case.describe_to runner
+      end
+    end
+
+    context 'with passing and undefined steps' do
+      let(:test_steps) { [passing, undefined] }
+
+      it 'reports the test case as undefined' do
+        report.should_receive(:after_test_case) do |test_case, result|
+          result.should be_undefined
+        end
+        test_case.describe_to runner
+      end
+
+      it 'reports the passing step as skipped' do
+        report.should_receive(:after_test_step).with(passing, anything) do |test_case, result|
+          result.should be_skipped
+        end
+        test_case.describe_to runner
+      end
+
+      it 'reports the undefined step as undefined' do
+        report.should_receive(:after_test_step).with(undefined, anything) do |test_case, result|
+          result.should be_undefined
+        end
+        test_case.describe_to runner
+      end
+    end
+
+    context 'with multiple test cases' do
+      context 'when the first test case is undefined' do
+        let(:first_test_case) { Case.new([undefined], source) }
+        let(:last_test_case)  { Case.new([passing], source) }
+        let(:test_cases)      { [first_test_case, last_test_case] }
+
+        it 'reports the results correctly for the following test case' do
+          report.
+            should_receive(:after_test_case).
+            with(last_test_case, anything) do |reported_test_case, result|
+            result.should be_skipped
+            end
+
+          test_cases.each { |c| c.describe_to runner }
+        end
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This supersedes #31.

Added a strategy for the test run mode. These include:
- `:default` - Executes all test steps and reports the status of the test
  case back to the report.
- `:dry_run` - Skips all test steps and reports back the status of the test
  case back to the report.

The strategy will default to the `:default` run mode if no mode is specified.
The run mode can be passed to `Cucumber::Core#execute` via the `run_options`
argument.

TODO: @mattwynne has suggested that the `Status::Monitor` is a bad name. He
suggests that this be renamed to `StepRunner`. I think this should be done as a
separate PR.
