### PR TITLE
Add gherkin_statement accessor to Ast::ScenarioOutline and Ast::ExamplesTable

### DIFF
--- a/lib/cucumber/core/ast/examples_table.rb
+++ b/lib/cucumber/core/ast/examples_table.rb
@@ -16,6 +16,10 @@ module Cucumber
           :location, :comments, :tags, :keyword, :name, :description, :header, :example_rows
         )
 
+        def gherkin_statement(node=nil)
+          @gherkin_statement ||= node
+        end
+
         private
 
         def description_for_visitors

--- a/lib/cucumber/core/ast/scenario_outline.rb
+++ b/lib/cucumber/core/ast/scenario_outline.rb
@@ -22,8 +22,8 @@ module Cucumber
 
         attr_reader :comments, :tags, :keyword, :background, :location
 
-        def gherkin_statement(node)
-          @gherkin_statement = node
+        def gherkin_statement(node=nil)
+          @gherkin_statement ||= node
         end
 
         private

--- a/lib/cucumber/core/gherkin/ast_builder.rb
+++ b/lib/cucumber/core/gherkin/ast_builder.rb
@@ -266,7 +266,7 @@ module Cucumber
           class ExamplesTableBuilder < Builder
 
             def result
-              Ast::ExamplesTable.new(
+              examples_table = Ast::ExamplesTable.new(
                 location,
                 comments,
                 tags,
@@ -276,6 +276,8 @@ module Cucumber
                 header,
                 example_rows
               )
+              examples_table.gherkin_statement(node)
+              examples_table
             end
 
             private


### PR DESCRIPTION
The Cucumber JSON formatter uses the gherkin_statement method on the AST classes, and it is missing on Ast:ScenarioOutline and Ast::ExamplesTable (see cucumber/cucumber#707).
