### PR TITLE
Pass gherkin node to steps instantiated from outline steps

### DIFF
--- a/lib/cucumber/core/ast/outline_step.rb
+++ b/lib/cucumber/core/ast/outline_step.rb
@@ -22,7 +22,9 @@ module Cucumber
         end
 
         def to_step(row)
-          Ast::Step.new(language, location, keyword, row.expand(name), replace_multiline_arg(row))
+          step = Ast::Step.new(language, location, keyword, row.expand(name), replace_multiline_arg(row))
+          step.gherkin_statement(@gherkin_statement)
+          step
         end
 
         private

--- a/spec/cucumber/core/ast/outline_step_spec.rb
+++ b/spec/cucumber/core/ast/outline_step_spec.rb
@@ -35,6 +35,12 @@ module Cucumber
               expect( outline_step.to_step(row).name ).to eq 'a green cucumber'
             end
 
+            it "knows the name of the outline step" do
+              row = ExamplesTable::Row.new({'color' => 'green'}, 1, location)
+              outline_step.gherkin_statement(double(:name => name))
+              expect( outline_step.to_step(row).gherkin_statement.name ).to eq name
+            end
+
           end
 
           context "when the step has a DataTable" do


### PR DESCRIPTION
The instantiated step need to know the name of the outline step, so the
un-instantiated name can be displayed in the backtrace for failures (required by cucumber/cucumber#714).
