### PR TITLE
Idea: Source as objects not Arrays

### DIFF
--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -124,7 +124,7 @@ module Cucumber
         include Cucumber.initializer(:source, :receiver)
 
         def step(step)
-          receiver.on_step(source.with_step(step))
+          receiver.on_step source.with_step(step)
           self
         end
       end

--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -1,6 +1,7 @@
 require 'cucumber/initializer'
 require 'cucumber/core/test/case'
 require 'cucumber/core/test/step'
+require 'cucumber/core/source'
 
 module Cucumber
   module Core
@@ -62,14 +63,14 @@ module Cucumber
         end
 
         def background(background, &descend)
-          source = [@feature, background]
+          source = Source::Background.new(@feature, background)
           compiler = BackgroundCompiler.new(source, receiver)
           descend.call(compiler)
           self
         end
 
         def scenario(scenario, &descend)
-          source = [@feature, scenario]
+          source = Source::Scenario.new(@feature, scenario)
           scenario_compiler = ScenarioCompiler.new(source, receiver)
           descend.call(scenario_compiler)
           receiver.on_test_case(source)
@@ -77,7 +78,7 @@ module Cucumber
         end
 
         def scenario_outline(scenario_outline, &descend)
-          source = [@feature, scenario_outline]
+          source = Source::ScenarioOutline.new(@feature, scenario_outline)
           compiler = ScenarioOutlineCompiler.new(source, receiver)
           descend.call(compiler)
           self
@@ -101,9 +102,9 @@ module Cucumber
 
         def examples_table_row(row)
           steps(row).each do |step|
-            receiver.on_step(source + [@examples_table, row, step])
+            receiver.on_step source.with_step(@examples_table, row, step)
           end
-          receiver.on_test_case(source + [@examples_table, row])
+          receiver.on_test_case source.with_row(@examples_table, row)
           self
         end
 
@@ -123,7 +124,7 @@ module Cucumber
         include Cucumber.initializer(:source, :receiver)
 
         def step(step)
-          receiver.on_step(source + [step])
+          receiver.on_step(source.with_step(step))
           self
         end
       end
@@ -133,7 +134,7 @@ module Cucumber
         include Cucumber.initializer(:source, :receiver)
 
         def step(step)
-          receiver.on_background_step(source + [step])
+          receiver.on_background_step(source.with_step(step))
           self
         end
       end

--- a/lib/cucumber/core/source.rb
+++ b/lib/cucumber/core/source.rb
@@ -79,6 +79,6 @@ module Cucumber
       ScenarioOutlineStep = Source.new(:feature, :scenario_outline, :examples_table, :row, :step)
 
       ScenarioOutlineExamplesTableRow = Source.new(:feature, :scenario_outline, :examples_table, :row)
-      end
     end
   end
+end

--- a/lib/cucumber/core/source.rb
+++ b/lib/cucumber/core/source.rb
@@ -1,0 +1,101 @@
+module Cucumber
+  module Core
+    module Source
+
+      module DescribesNodes
+        def describe_to(visitor, *args)
+          nodes.reverse.each do |node|
+            node.describe_to(visitor, *args)
+          end
+        end
+      end
+
+      Background = Struct.new(:feature, :background) do
+        def with_step(step)
+          BackgroundStep.new(feature, background, step)
+        end
+      end
+
+      BackgroundStep = Struct.new(:feature, :background, :step)
+
+      Scenario = Struct.new(:feature, :scenario) do
+        include DescribesNodes
+
+        def location
+          scenario.location
+        end
+
+        def with_step(step)
+          ScenarioStep.new(feature, scenario, step)
+        end
+
+        def with_hook(hook)
+          ScenarioHook.new(feature, scenario, hook)
+        end
+
+        def nodes
+          [feature, scenario]
+        end
+
+      end
+
+      ScenarioStep = Struct.new(:feature, :scenario, :step) do
+        include DescribesNodes
+
+        def with_hook(hook)
+          ScenarioStepHook.new(feature, scenario, step, hook)
+        end
+
+        def nodes
+          [feature, scenario, step]
+        end
+      end
+
+      ScenarioHook = Struct.new(:feature, :scenario, :hook) do
+        include DescribesNodes
+
+        def nodes
+          [feature, scenario, hook]
+        end
+      end
+
+      ScenarioStepHook = Struct.new(:feature, :scenario, :step, :hook) do
+        include DescribesNodes
+
+        def nodes
+          [feature, scenario, step, hook]
+        end
+      end
+
+      ScenarioOutline = Struct.new(:feature, :scenario_outline) do
+        def with_step(examples_table, row, step)
+          ScenarioOutlineStep.new(feature, scenario_outline, examples_table, row, step)
+        end
+
+        def with_row(examples_table, row)
+          ScenarioOutlineExamplesTableRow.new(feature, scenario_outline, examples_table, row)
+        end
+      end
+
+      ScenarioOutlineStep = Struct.new(:feature, :scenario_outline, :examples_table, :row, :step) do
+        include DescribesNodes
+
+        def nodes
+          [feature, scenario_outline, examples_table, row, step]
+        end
+      end
+
+      ScenarioOutlineExamplesTableRow = Struct.new(:feature, :scenario_outline, :examples_table, :row) do
+        include DescribesNodes
+
+        def location
+          row.location
+        end
+
+        def nodes
+          [feature, scenario_outline, examples_table, row]
+        end
+      end
+    end
+  end
+end

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -74,16 +74,16 @@ module Cucumber
           "<#{self.class}: #{location}>"
         end
 
+        def feature
+          source.feature
+        end
+
         private
 
         def compose_around_hooks(visitor, *args, &block)
           around_hooks.reverse.reduce(block) do |continue, hook|
             -> { hook.describe_to(visitor, *args, &continue) }
           end.call
-        end
-
-        def feature
-          source.first
         end
 
         class NameBuilder

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -6,7 +6,7 @@ module Cucumber
     module Test
       class Case
         include Cucumber.initializer(:test_steps, :source, :around_hooks)
-        attr_reader :source
+        attr_reader :source, :test_steps
 
         def initialize(test_steps, source, around_hooks = [])
           super(test_steps, source, around_hooks)
@@ -28,9 +28,7 @@ module Cucumber
         end
 
         def describe_source_to(visitor, *args)
-          source.reverse.each do |node|
-            node.describe_to(visitor, *args)
-          end
+          source.describe_to(visitor, *args)
           self
         end
 
@@ -64,7 +62,7 @@ module Cucumber
         end
 
         def location
-          source.last.location
+          source.location
         end
 
         def match_locations?(queried_locations)

--- a/lib/cucumber/core/test/mapper.rb
+++ b/lib/cucumber/core/test/mapper.rb
@@ -138,7 +138,7 @@ module Cucumber
           def build_hook_step(block, hook_type, mapping_type)
             mapping = mapping_type.new(&block)
             hook = hook_type.new(mapping.location)
-            Step.new(source + [hook], mapping)
+            Step.new(source.with_hook(hook), mapping)
           end
 
         end

--- a/lib/cucumber/core/test/step.rb
+++ b/lib/cucumber/core/test/step.rb
@@ -10,7 +10,6 @@ module Cucumber
         attr_reader :source
 
         def initialize(source, mapping = Test::UndefinedAction.new)
-          raise ArgumentError if source.any?(&:nil?)
           @mapping = mapping
           super(source)
         end
@@ -20,9 +19,7 @@ module Cucumber
         end
 
         def describe_source_to(visitor, *args)
-          source.reverse.each do |node|
-            node.describe_to(visitor, *args)
-          end
+          source.describe_to(visitor, *args)
           self
         end
 
@@ -39,11 +36,11 @@ module Cucumber
         end
 
         def name
-          source.last.name
+          source.step.name
         end
 
         def location
-          source.last.location
+          source.step.location
         end
 
         def match_locations?(queried_locations)

--- a/spec/cucumber/core/ast/step_spec.rb
+++ b/spec/cucumber/core/ast/step_spec.rb
@@ -1,4 +1,6 @@
 require 'cucumber/core/ast/step'
+require 'cucumber/core/ast/empty_multiline_argument'
+require 'cucumber/core/ast/outline_step'
 
 module Cucumber
   module Core

--- a/spec/cucumber/core/compiler_spec.rb
+++ b/spec/cucumber/core/compiler_spec.rb
@@ -169,13 +169,13 @@ module Cucumber::Core
 
         it "sets the source correctly on the test steps" do
           expect( receiver ).to receive(:on_background_step).with(
-            [feature, background, background_step]
+            Source::BackgroundStep.new(feature, background, background_step)
           )
           expect( receiver ).to receive(:on_step).with(
-            [feature, scenario, scenario_step]
+            Source::ScenarioStep.new(feature, scenario, scenario_step)
           )
           expect( receiver ).to receive(:on_test_case).with(
-            [feature, scenario]
+            Source::Scenario.new(feature, scenario)
           )
           compiler.feature(feature) do |f|
             f.background(background) do |b|

--- a/spec/cucumber/core/compiler_spec.rb
+++ b/spec/cucumber/core/compiler_spec.rb
@@ -204,16 +204,16 @@ module Cucumber::Core
         it "sets the source correctly on the test steps" do
           allow( outline_step ).to receive(:to_step) { outline_ast_step }
           expect( receiver ).to receive(:on_step).with(
-            [feature, scenario_outline, examples_table_1, examples_table_1_row_1, outline_ast_step]
+            Source::ScenarioOutlineStep.new(feature, scenario_outline, examples_table_1, examples_table_1_row_1, outline_ast_step)
           ).ordered
           expect( receiver ).to receive(:on_test_case).with(
-            [feature, scenario_outline, examples_table_1, examples_table_1_row_1]
+            Source::ScenarioOutlineExamplesTableRow.new(feature, scenario_outline, examples_table_1, examples_table_1_row_1)
           ).ordered
           expect( receiver ).to receive(:on_step).with(
-            [feature, scenario_outline, examples_table_2, examples_table_2_row_1, outline_ast_step]
+            Source::ScenarioOutlineStep.new(feature, scenario_outline, examples_table_2, examples_table_2_row_1, outline_ast_step)
           ).ordered
           expect( receiver ).to receive(:on_test_case).with(
-            [feature, scenario_outline, examples_table_2, examples_table_2_row_1]
+            Source::ScenarioOutlineExamplesTableRow.new(feature, scenario_outline, examples_table_2, examples_table_2_row_1)
           ).ordered
           compiler.feature(feature) do |f|
             f.scenario_outline(scenario_outline) do |o|

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -3,6 +3,7 @@ require 'cucumber/core'
 require 'cucumber/core/gherkin/writer'
 require 'cucumber/core/platform'
 require 'cucumber/core/test/case'
+require 'cucumber/core/source'
 require 'unindent'
 
 module Cucumber
@@ -12,7 +13,7 @@ module Cucumber
         include Core
         include Core::Gherkin::Writer
 
-        let(:test_case) { Test::Case.new(test_steps, [feature, scenario]) }
+        let(:test_case) { Test::Case.new(test_steps, Source::Scenario.new(feature, scenario)) }
         let(:feature) { double }
         let(:scenario) { double }
         let(:test_steps) { [double, double] }

--- a/spec/cucumber/core/test/step_spec.rb
+++ b/spec/cucumber/core/test/step_spec.rb
@@ -1,67 +1,72 @@
 require 'cucumber/core/test/step'
+require 'cucumber/core/source'
 
-module Cucumber::Core::Test
-  describe Step do
-    let(:last_result) { double('last_result') }
+module Cucumber
+  module Core
+    module Test
+      describe Step do
+        let(:last_result) { double('last_result') }
 
-    describe "describing itself" do
-      it "describes itself to a visitor" do
-        visitor = double
-        args = double
-        test_step = Step.new([double])
-        expect( visitor ).to receive(:test_step).with(test_step, args)
-        test_step.describe_to(visitor, args)
-      end
+        describe "describing itself" do
+          it "describes itself to a visitor" do
+            visitor = double
+            args = double
+            test_step = Step.new(double)
+            expect( visitor ).to receive(:test_step).with(test_step, args)
+            test_step.describe_to(visitor, args)
+          end
 
-      it "describes its source to a visitor" do
-        feature, scenario, step_or_hook = double, double, double
-        visitor = double
-        args = double
-        expect( feature      ).to receive(:describe_to).with(visitor, args)
-        expect( scenario     ).to receive(:describe_to).with(visitor, args)
-        expect( step_or_hook ).to receive(:describe_to).with(visitor, args)
-        test_step = Step.new([feature, scenario, step_or_hook])
-        test_step.describe_source_to(visitor, args)
+          it "describes its source to a visitor" do
+            feature, scenario, step_or_hook = double, double, double
+            visitor = double
+            args = double
+            expect( feature      ).to receive(:describe_to).with(visitor, args)
+            expect( scenario     ).to receive(:describe_to).with(visitor, args)
+            expect( step_or_hook ).to receive(:describe_to).with(visitor, args)
+            test_step = Step.new(Source::ScenarioStep.new(feature, scenario, step_or_hook))
+            test_step.describe_source_to(visitor, args)
+          end
+        end
+
+        describe "executing" do
+          let(:ast_step) { double }
+
+          context "when a passing mapping exists" do
+            it "returns a passing result" do
+              test_step = Step.new([ast_step]).with_mapping {}
+              expect( test_step.execute(last_result) ).to be_passed
+            end
+          end
+
+          context "when a failing mapping exists" do
+            let(:exception) { StandardError.new('oops') }
+
+            it "returns a failing result" do
+              test_step = Step.new([ast_step]).with_mapping { raise exception }
+              result = test_step.execute(last_result)
+              expect( result           ).to be_failed
+              expect( result.exception ).to eq exception
+            end
+          end
+
+          context "with no mapping" do
+            it "returns an Undefined result" do
+              test_step = Step.new([ast_step])
+              result = test_step.execute(last_result)
+              expect( result           ).to be_undefined
+            end
+          end
+        end
+
+        it "exposes the name and location of the AST step or hook as attributes" do
+          name, location = double, double
+          step_or_hook = double(name: name, location: location)
+          test_step = Step.new(Core::Source::ScenarioStep.new(double, double, step_or_hook))
+          expect( test_step.name     ).to eq name
+          expect( test_step.location ).to eq location
+        end
+
       end
     end
-
-    describe "executing" do
-      let(:ast_step) { double }
-
-      context "when a passing mapping exists" do
-        it "returns a passing result" do
-          test_step = Step.new([ast_step]).with_mapping {}
-          expect( test_step.execute(last_result) ).to be_passed
-        end
-      end
-
-      context "when a failing mapping exists" do
-        let(:exception) { StandardError.new('oops') }
-
-        it "returns a failing result" do
-          test_step = Step.new([ast_step]).with_mapping { raise exception }
-          result = test_step.execute(last_result)
-          expect( result           ).to be_failed
-          expect( result.exception ).to eq exception
-        end
-      end
-
-      context "with no mapping" do
-        it "returns an Undefined result" do
-          test_step = Step.new([ast_step])
-          result = test_step.execute(last_result)
-          expect( result           ).to be_undefined
-        end
-      end
-    end
-
-    it "exposes the name and location of the AST step or hook as attributes" do
-      name, location = double, double
-      step_or_hook = double(name: name, location: location)
-      test_step = Step.new([step_or_hook])
-      expect( test_step.name     ).to eq name
-      expect( test_step.location ).to eq location
-    end
-
   end
 end


### PR DESCRIPTION
I've been considering this for a while. This is just a sketch, and needs 
cleaning up, but it illustrates the idea.

I think it will improve the API by giving people another option for querying
the shape of `Test::Case` and `Test::Step` objects other than using the
visitor pattern.

My gut feeling is that by using types rather than Arrays, we might also catch
some bugs. We're now modelling the source more precisely, by capturing this
information during the compile.

The downsides are that the source objects feel quite like they're just 
boilerplate - there's no logic in them yet. The tests have also got a bit more
awkward - having to create Source objects instead of just arrays.

I think the tests could now leverage this source API in some places, but I
haven't tried that out yet.

@tooky @brasmusson I'm interested in your thoughts.