### PR TITLE
Handle empty feature files

### DIFF
--- a/lib/cucumber/core/ast/feature.rb
+++ b/lib/cucumber/core/ast/feature.rb
@@ -51,6 +51,12 @@ module Cucumber
         end
 
       end
+
+      class NullFeature
+        def method_missing(*args, &block)
+          self
+        end
+      end
     end
   end
 end

--- a/lib/cucumber/core/gherkin/ast_builder.rb
+++ b/lib/cucumber/core/gherkin/ast_builder.rb
@@ -12,10 +12,11 @@ module Cucumber
 
         def initialize(path)
           @path = path
+          @feature_builder = nil
         end
 
         def result
-          return nil unless @feature_builder
+          return Ast::NullFeature.new unless @feature_builder
           @feature_builder.result(language)
         end
 

--- a/spec/cucumber/core/gherkin/parser_spec.rb
+++ b/spec/cucumber/core/gherkin/parser_spec.rb
@@ -27,6 +27,24 @@ module Cucumber
           end
         end
 
+        RSpec::Matchers.define :a_null_feature do
+          match do |actual|
+            allow( visitor ).to receive(:feature).and_throw
+
+            actual.describe_to( visitor )
+          end
+        end
+
+        context "for empty files" do
+          let(:source) { Gherkin::Document.new(path, '') }
+          let(:path)   { 'path_to/the.feature' }
+
+          it "creates a NullFeature" do
+            expect( receiver ).to receive(:feature).with(a_null_feature)
+            parse
+          end
+        end
+
         include Writer
         def self.source(&block)
           let(:source) { gherkin(&block) }


### PR DESCRIPTION
An totally empty feature file should not result in an undefined method error, see https://github.com/cucumber/cucumber/issues/771.

Running an empty feature file in Cucumber v1.3.x results in:

```
0 scenarios
0 steps
0m0.000s
```

So that should be the behaviour also of Cucumber v2.0.

Closes https://github.com/cucumber/cucumber/issues/771
