### PR TITLE
names in Test::Case

### DIFF
--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -47,6 +47,10 @@ module Cucumber
         def name
           @name ||= NameBuilder.new(self).result
         end
+        
+        def keyword
+          @keyword ||= NameBuilder.new(self).keyword
+        end
 
         def tags
           @tags ||= TagCollector.new(self).result
@@ -92,6 +96,7 @@ module Cucumber
 
         class NameBuilder
           attr_reader :result
+          attr_reader :keyword
 
           def initialize(test_case)
             test_case.describe_source_to self
@@ -102,12 +107,14 @@ module Cucumber
           end
 
           def scenario(scenario)
-            @result = "#{scenario.name}"
+            @result = scenario.name
+            @keyword = scenario.keyword
             self
           end
 
           def scenario_outline(outline)
-            @result = "#{outline.name}" + @result
+            @result = outline.name + @result
+            @keyword = outline.keyword
             self
           end
 

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -48,10 +48,6 @@ module Cucumber
           @name ||= NameBuilder.new(self).result
         end
 
-        def simple_name
-          @simple_name ||= NameBuilder.new(self).simple_name
-        end
-
         def tags
           @tags ||= TagCollector.new(self).result
         end
@@ -96,7 +92,6 @@ module Cucumber
 
         class NameBuilder
           attr_reader :result
-          attr_reader :simple_name
 
           def initialize(test_case)
             test_case.describe_source_to self
@@ -107,14 +102,12 @@ module Cucumber
           end
 
           def scenario(scenario)
-            @simple_name = "#{scenario.name}"
-            @result = "#{scenario.keyword}: #{scenario.name}"
+            @result = "#{scenario.name}"
             self
           end
 
           def scenario_outline(outline)
-            @simple_name = "#{outline.name}" + @result
-            @result = "#{outline.keyword}: #{outline.name}" + @result
+            @result = "#{outline.name}" + @result
             self
           end
 

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -48,6 +48,10 @@ module Cucumber
           @name ||= NameBuilder.new(self).result
         end
 
+        def simple_name
+          @simple_name ||= NameBuilder.new(self).simple_name
+        end
+
         def tags
           @tags ||= TagCollector.new(self).result
         end
@@ -92,6 +96,7 @@ module Cucumber
 
         class NameBuilder
           attr_reader :result
+          attr_reader :simple_name
 
           def initialize(test_case)
             test_case.describe_source_to self
@@ -102,11 +107,13 @@ module Cucumber
           end
 
           def scenario(scenario)
+            @simple_name = "#{scenario.name}"
             @result = "#{scenario.keyword}: #{scenario.name}"
             self
           end
 
           def scenario_outline(outline)
+            @simple_name = "#{outline.name}" + @result
             @result = "#{outline.keyword}: #{outline.name}" + @result
             self
           end

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -68,6 +68,7 @@ module Cucumber
               receiver = double.as_null_object
 
               expect( receiver ).to receive(:test_case) do |test_case|
+                expect( test_case.simple_name ).to eq 'Scenario name'
                 expect( test_case.name ).to eq 'Scenario: Scenario name'
               end
               compile([gherkin], receiver)
@@ -96,12 +97,15 @@ module Cucumber
               end
               receiver = double.as_null_object
               expect( receiver ).to receive(:test_case) do |test_case|
+                expect( test_case.simple_name ).to eq 'outline name, examples name (row 1)'
                 expect( test_case.name ).to eq 'Scenario Outline: outline name, examples name (row 1)'
               end.once.ordered
               expect( receiver ).to receive(:test_case) do |test_case|
+                expect( test_case.simple_name ).to eq 'outline name, examples name (row 2)'
                 expect( test_case.name ).to eq 'Scenario Outline: outline name, examples name (row 2)'
               end.once.ordered
               expect( receiver ).to receive(:test_case) do |test_case|
+                expect( test_case.simple_name ).to eq 'outline name, Examples (row 1)'
                 expect( test_case.name ).to eq 'Scenario Outline: outline name, Examples (row 1)'
               end.once.ordered
               compile [gherkin], receiver
@@ -349,7 +353,7 @@ module Cucumber
           context "for a scenario outline" do
             let(:source) do
               Gherkin::Document.new(file, <<-END.unindent)
-                Feature: 
+                Feature:
 
                   Scenario: one
                     Given one a

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -68,8 +68,7 @@ module Cucumber
               receiver = double.as_null_object
 
               expect( receiver ).to receive(:test_case) do |test_case|
-                expect( test_case.simple_name ).to eq 'Scenario name'
-                expect( test_case.name ).to eq 'Scenario: Scenario name'
+                expect( test_case.name ).to eq 'Scenario name'
               end
               compile([gherkin], receiver)
             end
@@ -97,16 +96,13 @@ module Cucumber
               end
               receiver = double.as_null_object
               expect( receiver ).to receive(:test_case) do |test_case|
-                expect( test_case.simple_name ).to eq 'outline name, examples name (row 1)'
-                expect( test_case.name ).to eq 'Scenario Outline: outline name, examples name (row 1)'
+                expect( test_case.name ).to eq 'outline name, examples name (row 1)'
               end.once.ordered
               expect( receiver ).to receive(:test_case) do |test_case|
-                expect( test_case.simple_name ).to eq 'outline name, examples name (row 2)'
-                expect( test_case.name ).to eq 'Scenario Outline: outline name, examples name (row 2)'
+                expect( test_case.name ).to eq 'outline name, examples name (row 2)'
               end.once.ordered
               expect( receiver ).to receive(:test_case) do |test_case|
-                expect( test_case.simple_name ).to eq 'outline name, Examples (row 1)'
-                expect( test_case.name ).to eq 'Scenario Outline: outline name, Examples (row 1)'
+                expect( test_case.name ).to eq 'outline name, Examples (row 1)'
               end.once.ordered
               compile [gherkin], receiver
             end
@@ -277,7 +273,7 @@ module Cucumber
             end
 
             let(:test_case) do
-              test_cases.find { |c| c.name == 'Scenario: two' }
+              test_cases.find { |c| c.name == 'two' }
             end
 
             it 'matches the precise location of the scenario' do
@@ -286,7 +282,7 @@ module Cucumber
             end
 
             it 'matches the precise location of an empty scenario' do
-              empty_scenario_test_case = test_cases.find { |c| c.name == 'Scenario: empty' }
+              empty_scenario_test_case = test_cases.find { |c| c.name == 'empty' }
               location = Ast::Location.new(file, 26)
               expect( empty_scenario_test_case.match_locations?([location]) ).to be_truthy
             end
@@ -324,7 +320,7 @@ module Cucumber
 
             context "with a docstring" do
               let(:test_case) do
-                test_cases.find { |c| c.name == 'Scenario: with docstring' }
+                test_cases.find { |c| c.name == 'with docstring' }
               end
 
               it "matches a location at the start the docstring" do
@@ -340,7 +336,7 @@ module Cucumber
 
             context "with a table" do
               let(:test_case) do
-                test_cases.find { |c| c.name == 'Scenario: with a table' }
+                test_cases.find { |c| c.name == 'with a table' }
               end
 
               it "matches a location on the first table row" do
@@ -380,7 +376,7 @@ module Cucumber
             end
 
             let(:test_case) do
-              test_cases.find { |c| c.name == "Scenario Outline: two, x1 (row 1)" }
+              test_cases.find { |c| c.name == "two, x1 (row 1)" }
             end
 
             it 'matches the precise location of the scenario outline examples table row' do

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -69,6 +69,7 @@ module Cucumber
 
               expect( receiver ).to receive(:test_case) do |test_case|
                 expect( test_case.name ).to eq 'Scenario name'
+                expect( test_case.keyword ).to eq 'Scenario'
               end
               compile([gherkin], receiver)
             end
@@ -97,6 +98,7 @@ module Cucumber
               receiver = double.as_null_object
               expect( receiver ).to receive(:test_case) do |test_case|
                 expect( test_case.name ).to eq 'outline name, examples name (row 1)'
+                expect( test_case.keyword ).to eq 'Scenario Outline'
               end.once.ordered
               expect( receiver ).to receive(:test_case) do |test_case|
                 expect( test_case.name ).to eq 'outline name, examples name (row 2)'

--- a/spec/cucumber/core_spec.rb
+++ b/spec/cucumber/core_spec.rb
@@ -48,7 +48,7 @@ module Cucumber
       it "filters out test cases based on a tag expression" do
         visitor = double.as_null_object
         expect( visitor ).to receive(:test_case) do |test_case|
-          expect( test_case.name ).to eq 'Scenario Outline: foo, bar (row 1)'
+          expect( test_case.name ).to eq 'foo, bar (row 1)'
         end.exactly(1).times
 
         gherkin = gherkin do
@@ -283,10 +283,10 @@ module Cucumber
           expect( report.test_cases.total_passed ).to eq 1
           expect( report.test_cases.total_failed ).to eq 0
           expect( logger ).to eq [
-            :before_all, 
-              :step, 
-            :middle, 
-              :step, 
+            :before_all,
+              :step,
+            :middle,
+              :step,
             :after_all
           ]
         end


### PR DESCRIPTION
This PR starts working on [cucumber issue #768](https://github.com/cucumber/cucumber/issues/768) where we want a name like "scenario name" not "Scenario: scenario name"

@mattwynne and @akostadinov, let me know if this is the direction you were thinking.  There were two other requests in the issue about wanting values from an example table and a separate method to get row numbers, but I'm not entirely sure what the end goal is.

How would these details be used? ... Can you give me an example? :smile: 

I'm not completely sure just sticking on extra results to the `NameBuilder` is the way to go either, but this does give the simplified name now.