### PR TITLE
Make the result objects usable in the new formatter api

### DIFF
--- a/lib/cucumber/core/test/result.rb
+++ b/lib/cucumber/core/test/result.rb
@@ -81,12 +81,8 @@ module Cucumber
           end
 
           def with_appended_backtrace(step)
-            return self unless step.respond_to?(:backtrace_line)
-            new_exception = exception.dup
-            new_exception.set_backtrace([])
-            exception.backtrace.each { |line| new_exception.backtrace << line }
-            new_exception.backtrace << step.backtrace_line
-            self.class.new(duration, new_exception)
+            exception.backtrace << step.backtrace_line if step.respond_to?(:backtrace_line)
+            self
           end
 
           def with_filtered_backtrace(filter)
@@ -115,10 +111,9 @@ module Cucumber
 
           def with_appended_backtrace(step)
             return self unless step.respond_to?(:backtrace_line)
-            new_backtrace = []
-            backtrace.each { |line| new_backtrace << line } if backtrace
-            new_backtrace << step.backtrace_line
-            self.class.new(message, duration, new_backtrace)
+            set_backtrace([]) unless backtrace
+            backtrace << step.backtrace_line
+            self
           end
 
           def with_filtered_backtrace(filter)

--- a/lib/cucumber/core/test/runner.rb
+++ b/lib/cucumber/core/test/runner.rb
@@ -97,6 +97,8 @@ module Cucumber
 
               def execute(test_step, monitor, &continue)
                 result = test_step.execute(monitor.result, &continue)
+                result = result.with_message(%(Undefined step: "#{test_step.name}")) if result.undefined?
+                result = result.with_appended_backtrace(test_step.source.last) if test_step.respond_to?(:source)
                 result.describe_to(monitor, result)
               end
 

--- a/spec/cucumber/core/test/runner_spec.rb
+++ b/spec/cucumber/core/test/runner_spec.rb
@@ -112,7 +112,7 @@ module Cucumber::Core::Test
             test_case.describe_to runner
           end
 
-          it 'gets backtrace appended' do
+          it 'appends the backtrace of the result' do
             expect( report ).to receive(:after_test_case) do |test_case, result|
               expect( result.backtrace ).to eq(["step line"])
             end
@@ -132,7 +132,7 @@ module Cucumber::Core::Test
             test_case.describe_to runner
           end
 
-          it 'gets its backtrace appended' do
+          it 'appends the backtrace of the result' do
             expect( report ).to receive(:after_test_case) do |test_case, result|
               expect( result.backtrace.last ).to eq("step line")
             end
@@ -151,7 +151,7 @@ module Cucumber::Core::Test
             test_case.describe_to runner
           end
 
-          it 'gets its backtrace appended' do
+          it 'appends the backtrace of the result' do
             expect( report ).to receive(:after_test_case) do |test_case, result|
               expect( result.backtrace.last ).to eq("step line")
             end
@@ -170,7 +170,7 @@ module Cucumber::Core::Test
             test_case.describe_to runner
           end
 
-          it 'gets its exception backtrace appended' do
+          it 'appends the backtrace of the exception of the result' do
             expect( report ).to receive(:after_test_case) do |test_case, result|
               expect( result.exception.backtrace.last ).to eq("step line")
             end

--- a/spec/cucumber/core/test/runner_spec.rb
+++ b/spec/cucumber/core/test/runner_spec.rb
@@ -100,6 +100,24 @@ module Cucumber::Core::Test
             expect( report ).to receive(:after_test_case) do |test_case, result|
               expect( result ).to be_undefined
             end
+            allow( undefined.source.last ).to receive(:name)
+            test_case.describe_to runner
+          end
+
+          it 'sets the message on the result' do
+            expect( report ).to receive(:after_test_case) do |test_case, result|
+              expect( result.message ).to eq("Undefined step: \"step name\"")
+            end
+            expect( undefined.source.last ).to receive(:name).and_return("step name")
+            test_case.describe_to runner
+          end
+
+          it 'gets backtrace appended' do
+            expect( report ).to receive(:after_test_case) do |test_case, result|
+              expect( result.backtrace ).to eq(["step line"])
+            end
+            expect( undefined.source.last ).to receive(:backtrace_line).and_return("step line")
+            allow( undefined.source.last ).to receive(:name)
             test_case.describe_to runner
           end
         end
@@ -113,6 +131,14 @@ module Cucumber::Core::Test
             end
             test_case.describe_to runner
           end
+
+          it 'gets its backtrace appended' do
+            expect( report ).to receive(:after_test_case) do |test_case, result|
+              expect( result.backtrace.last ).to eq("step line")
+            end
+            expect( pending.source.last ).to receive(:backtrace_line).and_return("step line")
+            test_case.describe_to runner
+          end
         end
 
         context "a skipping step" do
@@ -124,6 +150,14 @@ module Cucumber::Core::Test
             end
             test_case.describe_to runner
           end
+
+          it 'gets its backtrace appended' do
+            expect( report ).to receive(:after_test_case) do |test_case, result|
+              expect( result.backtrace.last ).to eq("step line")
+            end
+            expect( skipping.source.last ).to receive(:backtrace_line).and_return("step line")
+            test_case.describe_to runner
+          end
         end
 
         context 'that fail' do
@@ -133,6 +167,14 @@ module Cucumber::Core::Test
             expect( report ).to receive(:after_test_case) do |test_case, result|
               expect( result ).to be_failed
             end
+            test_case.describe_to runner
+          end
+
+          it 'gets its exception backtrace appended' do
+            expect( report ).to receive(:after_test_case) do |test_case, result|
+              expect( result.exception.backtrace.last ).to eq("step line")
+            end
+            expect( failing.source.last ).to receive(:backtrace_line).and_return("step line")
             test_case.describe_to runner
           end
         end


### PR DESCRIPTION
To make the result objects usable in the new formatter api:
* Set the message on undefined results.
* Append the backtrace with the backtrace line of the step on results that either have an exception (with backtrace) or have a backtrace themselves.
* Support applying filters on the backtrace.

Required by cucumber/cucumber#843.