### PR TITLE
Add Result#non_zero_exit_status?

### DIFF
--- a/lib/cucumber/core/test/result.rb
+++ b/lib/cucumber/core/test/result.rb
@@ -51,8 +51,8 @@ module Cucumber
             "✓"
           end
 
-          def non_zero_exit_status?(is_strict)
-            false
+          def ok?(be_strict)
+            true
           end
 
           def with_appended_backtrace(step)
@@ -86,8 +86,8 @@ module Cucumber
             "✗"
           end
 
-          def non_zero_exit_status?(is_strict)
-            true
+          def ok?(be_strict)
+            false
           end
 
           def with_duration(new_duration)
@@ -149,8 +149,8 @@ module Cucumber
             "?"
           end
 
-          def non_zero_exit_status?(is_strict)
-            is_strict
+          def ok?(be_strict)
+            !be_strict
           end
         end
 
@@ -167,8 +167,8 @@ module Cucumber
             "-"
           end
 
-          def non_zero_exit_status?(is_strict)
-            false
+          def ok?(be_strict)
+            true
           end
         end
 
@@ -185,8 +185,8 @@ module Cucumber
             "P"
           end
 
-          def non_zero_exit_status?(is_strict)
-            is_strict
+          def ok?(be_strict)
+            !be_strict
           end
         end
 

--- a/lib/cucumber/core/test/result.rb
+++ b/lib/cucumber/core/test/result.rb
@@ -51,6 +51,10 @@ module Cucumber
             "✓"
           end
 
+          def non_zero_exit_status?(is_strict)
+            false
+          end
+
           def with_appended_backtrace(step)
             self
           end
@@ -80,6 +84,10 @@ module Cucumber
 
           def to_s
             "✗"
+          end
+
+          def non_zero_exit_status?(is_strict)
+            true
           end
 
           def with_duration(new_duration)
@@ -141,6 +149,9 @@ module Cucumber
             "?"
           end
 
+          def non_zero_exit_status?(is_strict)
+            is_strict
+          end
         end
 
         class Skipped < Raisable
@@ -156,6 +167,9 @@ module Cucumber
             "-"
           end
 
+          def non_zero_exit_status?(is_strict)
+            false
+          end
         end
 
         class Pending < Raisable
@@ -169,6 +183,10 @@ module Cucumber
 
           def to_s
             "P"
+          end
+
+          def non_zero_exit_status?(is_strict)
+            is_strict
           end
         end
 

--- a/lib/cucumber/core/test/result.rb
+++ b/lib/cucumber/core/test/result.rb
@@ -51,7 +51,7 @@ module Cucumber
             "✓"
           end
 
-          def ok?(be_strict)
+          def ok?(be_strict = false)
             true
           end
 
@@ -86,7 +86,7 @@ module Cucumber
             "✗"
           end
 
-          def ok?(be_strict)
+          def ok?(be_strict = false)
             false
           end
 
@@ -149,7 +149,7 @@ module Cucumber
             "?"
           end
 
-          def ok?(be_strict)
+          def ok?(be_strict = false)
             !be_strict
           end
         end
@@ -167,7 +167,7 @@ module Cucumber
             "-"
           end
 
-          def ok?(be_strict)
+          def ok?(be_strict = false)
             true
           end
         end
@@ -185,7 +185,7 @@ module Cucumber
             "P"
           end
 
-          def ok?(be_strict)
+          def ok?(be_strict = false)
             !be_strict
           end
         end

--- a/spec/cucumber/core/test/result_spec.rb
+++ b/spec/cucumber/core/test/result_spec.rb
@@ -45,6 +45,9 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_undefined }
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).not_to be_skipped   }
+
+      specify { expect( result.non_zero_exit_status?(false) ).to be_falsey }
+      specify { expect( result.non_zero_exit_status?(true) ).to be_falsey }
     end
 
     describe Result::Failed do
@@ -100,6 +103,9 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_undefined }
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).not_to be_skipped   }
+
+      specify { expect( result.non_zero_exit_status?(false) ).to be_truthy }
+      specify { expect( result.non_zero_exit_status?(true) ).to be_truthy }
     end
 
     describe Result::Unknown do
@@ -183,6 +189,9 @@ module Cucumber::Core::Test
       specify { expect( result ).to     be_undefined }
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).not_to be_skipped   }
+
+      specify { expect( result.non_zero_exit_status?(false) ).to be_falsey }
+      specify { expect( result.non_zero_exit_status?(true) ).to be_truthy }
     end
 
     describe Result::Skipped do
@@ -201,6 +210,31 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_undefined }
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).to     be_skipped   }
+
+      specify { expect( result.non_zero_exit_status?(false) ).to be_falsey }
+      specify { expect( result.non_zero_exit_status?(true) ).to be_falsey }
+    end
+
+    describe Result::Pending do
+      subject(:result) { Result::Pending.new }
+
+      it "describes itself to a visitor" do
+        expect( visitor ).to receive(:pending).with(result, args)
+        expect( visitor ).to receive(:duration).with(an_unknown_duration, args)
+        result.describe_to(visitor, args)
+      end
+
+      specify { expect( result.to_sym ).to eq :pending }
+
+      specify { expect( result ).not_to be_passed    }
+      specify { expect( result ).not_to be_failed    }
+      specify { expect( result ).not_to be_undefined }
+      specify { expect( result ).not_to be_unknown   }
+      specify { expect( result ).not_to be_skipped   }
+      specify { expect( result ).to     be_pending   }
+
+      specify { expect( result.non_zero_exit_status?(false) ).to be_falsey }
+      specify { expect( result.non_zero_exit_status?(true) ).to be_truthy }
     end
 
     describe Result::Summary do

--- a/spec/cucumber/core/test/result_spec.rb
+++ b/spec/cucumber/core/test/result_spec.rb
@@ -46,8 +46,8 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).not_to be_skipped   }
 
-      specify { expect( result.non_zero_exit_status?(false) ).to be_falsey }
-      specify { expect( result.non_zero_exit_status?(true) ).to be_falsey }
+      specify { expect( result.ok?(false) ).to be_truthy }
+      specify { expect( result.ok?(true) ).to be_truthy }
     end
 
     describe Result::Failed do
@@ -104,8 +104,8 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).not_to be_skipped   }
 
-      specify { expect( result.non_zero_exit_status?(false) ).to be_truthy }
-      specify { expect( result.non_zero_exit_status?(true) ).to be_truthy }
+      specify { expect( result.ok?(false) ).to be_falsey }
+      specify { expect( result.ok?(true) ).to be_falsey }
     end
 
     describe Result::Unknown do
@@ -190,8 +190,8 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).not_to be_skipped   }
 
-      specify { expect( result.non_zero_exit_status?(false) ).to be_falsey }
-      specify { expect( result.non_zero_exit_status?(true) ).to be_truthy }
+      specify { expect( result.ok?(false) ).to be_truthy }
+      specify { expect( result.ok?(true) ).to be_falsey }
     end
 
     describe Result::Skipped do
@@ -211,8 +211,8 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).to     be_skipped   }
 
-      specify { expect( result.non_zero_exit_status?(false) ).to be_falsey }
-      specify { expect( result.non_zero_exit_status?(true) ).to be_falsey }
+      specify { expect( result.ok?(false) ).to be_truthy }
+      specify { expect( result.ok?(true) ).to be_truthy }
     end
 
     describe Result::Pending do
@@ -233,8 +233,8 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_skipped   }
       specify { expect( result ).to     be_pending   }
 
-      specify { expect( result.non_zero_exit_status?(false) ).to be_falsey }
-      specify { expect( result.non_zero_exit_status?(true) ).to be_truthy }
+      specify { expect( result.ok?(false) ).to be_truthy }
+      specify { expect( result.ok?(true) ).to be_falsey }
     end
 
     describe Result::Summary do

--- a/spec/cucumber/core/test/result_spec.rb
+++ b/spec/cucumber/core/test/result_spec.rb
@@ -46,6 +46,7 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).not_to be_skipped   }
 
+      specify { expect( result ).to be_ok }
       specify { expect( result.ok?(false) ).to be_truthy }
       specify { expect( result.ok?(true) ).to be_truthy }
     end
@@ -104,6 +105,7 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).not_to be_skipped   }
 
+      specify { expect( result ).to_not be_ok }
       specify { expect( result.ok?(false) ).to be_falsey }
       specify { expect( result.ok?(true) ).to be_falsey }
     end
@@ -190,6 +192,7 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).not_to be_skipped   }
 
+      specify { expect( result ).to be_ok }
       specify { expect( result.ok?(false) ).to be_truthy }
       specify { expect( result.ok?(true) ).to be_falsey }
     end
@@ -211,6 +214,7 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).to     be_skipped   }
 
+      specify { expect( result ).to be_ok }
       specify { expect( result.ok?(false) ).to be_truthy }
       specify { expect( result.ok?(true) ).to be_truthy }
     end
@@ -233,6 +237,7 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_skipped   }
       specify { expect( result ).to     be_pending   }
 
+      specify { expect( result ).to be_ok }
       specify { expect( result.ok?(false) ).to be_truthy }
       specify { expect( result.ok?(true) ).to be_falsey }
     end


### PR DESCRIPTION
This could simplify logic where Pending and Undefined results in strict mode shall be handled in the same way as Failed results.

The first to use it is the JUnit Formatter (cucumber/cucumber#855)