### PR TITLE
Use Gherkin3 instead  of Gherkin2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source "https://rubygems.org"
 gemspec
+
+gem 'gherkin', github: "cucumber/gherkin3", branch: "integrate-ruby-core"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,2 @@
 source "https://rubygems.org"
 gemspec
-
-gem 'gherkin3', github: "cucumber/gherkin3", branch: "integrate-ruby-core"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 gemspec
 
-gem 'gherkin', github: "cucumber/gherkin3", branch: "integrate-ruby-core"
+gem 'gherkin3', github: "cucumber/gherkin3", branch: "integrate-ruby-core"

--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = ">= 1.9.3"
 
-  s.add_dependency 'gherkin', '~> 2.12.0'
+  s.add_dependency 'gherkin', '~> 3.0.0.alpha.1'
 
   s.add_development_dependency 'bundler',   '>= 1.3.5'
   s.add_development_dependency 'rake',      '>= 0.9.2'

--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = ">= 1.9.3"
 
-  s.add_dependency 'gherkin3', '~> 3.0.0.alpha.1'
+  s.add_dependency 'gherkin3', '~> 3.0.0'
 
   s.add_development_dependency 'bundler',   '>= 1.3.5'
   s.add_development_dependency 'rake',      '>= 0.9.2'

--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = ">= 1.9.3"
 
-  s.add_dependency 'gherkin3', '~> 3.0.0'
+  s.add_dependency 'gherkin3', '~> 3.1.0'
 
   s.add_development_dependency 'bundler',   '>= 1.3.5'
   s.add_development_dependency 'rake',      '>= 0.9.2'

--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = ">= 1.9.3"
 
-  s.add_dependency 'gherkin', '~> 3.0.0.alpha.1'
+  s.add_dependency 'gherkin3', '~> 3.0.0.alpha.1'
 
   s.add_development_dependency 'bundler',   '>= 1.3.5'
   s.add_development_dependency 'rake',      '>= 0.9.2'

--- a/lib/cucumber/core/ast/background.rb
+++ b/lib/cucumber/core/ast/background.rb
@@ -10,9 +10,7 @@ module Cucumber
         include HasLocation
         include DescribesItself
 
-        def initialize(gherkin_statement, language, location, comments, keyword, name, description, raw_steps)
-          @gherkin_statement = gherkin_statement
-          @language = language
+        def initialize(location, comments, keyword, name, description, raw_steps)
           @location = location
           @comments = comments
           @keyword = keyword
@@ -21,11 +19,10 @@ module Cucumber
           @raw_steps = raw_steps
         end
 
-        attr_reader :language, :description, :raw_steps
-        private     :language, :raw_steps
+        attr_reader :description, :raw_steps
+        private     :raw_steps
 
         attr_reader :comments, :keyword, :location
-        attr_reader :gherkin_statement
 
         def children
           raw_steps

--- a/lib/cucumber/core/ast/data_table.rb
+++ b/lib/cucumber/core/ast/data_table.rb
@@ -1,6 +1,3 @@
-require 'gherkin/rubify'
-require 'gherkin/lexer/i18n_lexer'
-require 'gherkin/formatter/escaping'
 require 'cucumber/core/ast/describes_itself'
 require 'cucumber/core/ast/location'
 
@@ -30,15 +27,13 @@ module Cucumber
         include DescribesItself
         include HasLocation
 
-        include ::Gherkin::Rubify
-
         # Creates a new instance. +raw+ should be an Array of Array of String
         # or an Array of Hash
         # You don't typically create your own DataTable objects - Cucumber will do
         # it internally and pass them to your Step Definitions.
         #
-        def initialize(raw, location)
-          raw = ensure_array_of_array(rubify(raw))
+        def initialize(rows:, location:)
+          raw = ensure_array_of_array(rows)
           verify_rows_are_same_length(raw)
           @raw = raw.freeze
           @location = location

--- a/lib/cucumber/core/ast/data_table.rb
+++ b/lib/cucumber/core/ast/data_table.rb
@@ -32,7 +32,7 @@ module Cucumber
         # You don't typically create your own DataTable objects - Cucumber will do
         # it internally and pass them to your Step Definitions.
         #
-        def initialize(rows:, location:)
+        def initialize(rows, location)
           raw = ensure_array_of_array(rows)
           verify_rows_are_same_length(raw)
           @raw = raw.freeze

--- a/lib/cucumber/core/ast/describes_itself.rb
+++ b/lib/cucumber/core/ast/describes_itself.rb
@@ -5,7 +5,12 @@ module Cucumber
         def describe_to(visitor, *args)
           visitor.send(description_for_visitors, self, *args) do |child_visitor|
             children.each do |child|
-              child.describe_to(child_visitor, *args)
+              begin
+                child.describe_to(child_visitor, *args)
+              rescue => e
+                p children
+                raise e.class, "Failed describing child of #{self.inspect} - #{e.message}", e.backtrace
+              end
             end
           end
           self

--- a/lib/cucumber/core/ast/describes_itself.rb
+++ b/lib/cucumber/core/ast/describes_itself.rb
@@ -8,7 +8,6 @@ module Cucumber
               begin
                 child.describe_to(child_visitor, *args)
               rescue => e
-                p children
                 raise e.class, "Failed describing child of #{self.inspect} - #{e.message}", e.backtrace
               end
             end

--- a/lib/cucumber/core/ast/doc_string.rb
+++ b/lib/cucumber/core/ast/doc_string.rb
@@ -25,8 +25,8 @@ module Cucumber
 
         attr_reader :content_type, :content
 
-        def initialize(string, content_type, location)
-          @content = string
+        def initialize(content:nil, content_type:nil, location: nil)
+          @content = content
           @content_type = content_type
           @location = location
           super @content

--- a/lib/cucumber/core/ast/doc_string.rb
+++ b/lib/cucumber/core/ast/doc_string.rb
@@ -25,7 +25,7 @@ module Cucumber
 
         attr_reader :content_type, :content
 
-        def initialize(content:nil, content_type:nil, location: nil)
+        def initialize(content, content_type, location)
           @content = content
           @content_type = content_type
           @location = location

--- a/lib/cucumber/core/ast/examples_table.rb
+++ b/lib/cucumber/core/ast/examples_table.rb
@@ -11,10 +11,8 @@ module Cucumber
         include HasLocation
         include DescribesItself
 
-        def initialize(gherkin_statement, location, comments, tags, keyword, name, description, header, example_rows)
-          @gherkin_statement = gherkin_statement
+        def initialize(location:, tags:, keyword:, name:, description: "", header:, example_rows:)
           @location = location
-          @comments = comments
           @tags = tags
           @keyword = keyword
           @name = name
@@ -23,7 +21,7 @@ module Cucumber
           @example_rows = example_rows
         end
 
-        attr_reader :gherkin_statement, :location, :comments, :tags, :keyword,
+        attr_reader :location, :tags, :keyword,
                     :header, :example_rows
 
         private
@@ -109,6 +107,7 @@ module Cucumber
           end
         end
       end
+      class Examples < ExamplesTable; end
     end
   end
 end

--- a/lib/cucumber/core/ast/examples_table.rb
+++ b/lib/cucumber/core/ast/examples_table.rb
@@ -11,8 +11,9 @@ module Cucumber
         include HasLocation
         include DescribesItself
 
-        def initialize(location:, tags:, keyword:, name:, description: "", header:, example_rows:)
+        def initialize(location, comments, tags, keyword, name, description, header, example_rows)
           @location = location
+          @comments = comments
           @tags = tags
           @keyword = keyword
           @name = name
@@ -21,7 +22,7 @@ module Cucumber
           @example_rows = example_rows
         end
 
-        attr_reader :location, :tags, :keyword,
+        attr_reader :location, :tags, :keyword, :comments,
                     :header, :example_rows
 
         private

--- a/lib/cucumber/core/ast/feature.rb
+++ b/lib/cucumber/core/ast/feature.rb
@@ -11,12 +11,11 @@ module Cucumber
         include HasLocation
         include DescribesItself
 
-        attr_reader :gherkin_statement, :language, :location, :background,
+        attr_reader :language, :location, :background,
                     :comments, :tags, :keyword, :description,
                     :feature_elements
 
-        def initialize(gherkin_statement, language, location, background, comments, tags, keyword, name, description, feature_elements)
-          @gherkin_statement = gherkin_statement
+        def initialize(language:, location:, background: EmptyBackground.new, comments:, tags:, keyword:, name:, description: "", scenario_definitions:)
           @language = language
           @location = location
           @background = background
@@ -25,7 +24,7 @@ module Cucumber
           @keyword = keyword
           @name = name
           @description = description
-          @feature_elements = feature_elements
+          @feature_elements = scenario_definitions
         end
 
         def children

--- a/lib/cucumber/core/ast/feature.rb
+++ b/lib/cucumber/core/ast/feature.rb
@@ -34,7 +34,7 @@ module Cucumber
 
         def short_name
           first_line = name.split(/\n/)[0]
-          if first_line =~ /#{language.feature}:(.*)/
+          if first_line =~ /#{language.feature_keywords}:(.*)/
             $1.strip
           else
             first_line

--- a/lib/cucumber/core/ast/feature.rb
+++ b/lib/cucumber/core/ast/feature.rb
@@ -1,6 +1,7 @@
 require 'cucumber/core/ast/describes_itself'
 require 'cucumber/core/ast/names'
 require 'cucumber/core/ast/location'
+require 'gherkin3/dialect'
 
 module Cucumber
   module Core
@@ -15,7 +16,7 @@ module Cucumber
                     :comments, :tags, :keyword, :description,
                     :feature_elements
 
-        def initialize(language:, location:, background: EmptyBackground.new, comments:, tags:, keyword:, name:, description: "", scenario_definitions:)
+        def initialize(language, location, background, comments, tags, keyword, name, description, scenario_definitions)
           @language = language
           @location = location
           @background = background
@@ -33,7 +34,7 @@ module Cucumber
 
         def short_name
           first_line = name.split(/\n/)[0]
-          if first_line =~ /#{language.keywords('feature')}:(.*)/
+          if first_line =~ /#{language.feature}:(.*)/
             $1.strip
           else
             first_line
@@ -62,6 +63,15 @@ module Cucumber
       class NullFeature
         def method_missing(*args, &block)
           self
+        end
+      end
+
+      class LanguageDelegator < SimpleDelegator
+        attr_reader :iso_code
+
+        def initialize(iso_code, obj)
+          super(obj)
+          @iso_code = iso_code
         end
       end
     end

--- a/lib/cucumber/core/ast/location.rb
+++ b/lib/cucumber/core/ast/location.rb
@@ -79,9 +79,6 @@ module Cucumber
           attr_reader :line
 
           def initialize(raw_data)
-            if Cucumber::JRUBY && raw_data.is_a?(::Java::GherkinFormatterModel::Range)
-              raw_data = Range.new(raw_data.first, raw_data.last)
-            end
             super Array(raw_data).to_set
             @line = data.first
           end

--- a/lib/cucumber/core/ast/outline_step.rb
+++ b/lib/cucumber/core/ast/outline_step.rb
@@ -10,11 +10,10 @@ module Cucumber
         include HasLocation
         include DescribesItself
 
-        attr_reader :gherkin_statement, :language, :location, :comments, :keyword, :name, :multiline_arg
+        attr_reader :language, :location, :comments, :keyword, :name, :multiline_arg
 
-        def initialize(gherkin_statement, language, location, comments, keyword, name, multiline_arg)
-          @gherkin_statement, @language, @location, @comments, @keyword, @name, @multiline_arg = gherkin_statement, language, location, comments, keyword, name, multiline_arg
-          @language || raise("Language is required!")
+        def initialize(language, location, comments, keyword, name, multiline_arg)
+          @language, @location, @comments, @keyword, @name, @multiline_arg = language, location, comments, keyword, name, multiline_arg
         end
 
         def to_step(row)

--- a/lib/cucumber/core/ast/outline_step.rb
+++ b/lib/cucumber/core/ast/outline_step.rb
@@ -12,12 +12,12 @@ module Cucumber
 
         attr_reader :language, :location, :comments, :keyword, :name, :multiline_arg
 
-        def initialize(language, location, comments, keyword, name, multiline_arg)
-          @language, @location, @comments, @keyword, @name, @multiline_arg = language, location, comments, keyword, name, multiline_arg
+        def initialize(language, location, comments, keyword, text, multiline_arg)
+          @language, @location, @comments, @keyword, @name, @multiline_arg = language, location, comments, keyword, text, multiline_arg
         end
 
         def to_step(row)
-          Ast::ExpandedOutlineStep.new(self, gherkin_statement, language, row.location, comments, keyword, row.expand(name), replace_multiline_arg(row))
+          Ast::ExpandedOutlineStep.new(self, language, row.location, comments, keyword, row.expand(name), replace_multiline_arg(row))
         end
 
         def inspect

--- a/lib/cucumber/core/ast/scenario.rb
+++ b/lib/cucumber/core/ast/scenario.rb
@@ -11,23 +11,19 @@ module Cucumber
         include HasLocation
         include DescribesItself
 
-        attr_reader :gherkin_statement, :language, :location, :background,
-                    :comments, :tags, :feature_tags, :keyword,
+        attr_reader :language, :location, :background,
+                    :tags, :keyword,
                     :description, :raw_steps
         private :raw_steps
 
-        def initialize(gherkin_statement, language, location, background, comments, tags, feature_tags, keyword, name, description, raw_steps)
-          @gherkin_statement = gherkin_statement
+        def initialize(language: "TODO", location:, tags:, keyword:, name:, description: "", steps:)
           @language          = language
           @location          = location
-          @background        = background
-          @comments          = comments
           @tags              = tags
-          @feature_tags      = feature_tags
           @keyword           = keyword
           @name              = name
           @description       = description
-          @raw_steps         = raw_steps
+          @raw_steps         = steps
         end
 
         def children

--- a/lib/cucumber/core/ast/scenario.rb
+++ b/lib/cucumber/core/ast/scenario.rb
@@ -11,14 +11,14 @@ module Cucumber
         include HasLocation
         include DescribesItself
 
-        attr_reader :language, :location, :background,
-                    :tags, :keyword,
+        attr_reader :location, :background,
+                    :comments, :tags, :keyword,
                     :description, :raw_steps
         private :raw_steps
 
-        def initialize(language: "TODO", location:, tags:, keyword:, name:, description: "", steps:)
-          @language          = language
+        def initialize(location, comments, tags, keyword, name, description, steps)
           @location          = location
+          @comments          = comments
           @tags              = tags
           @keyword           = keyword
           @name              = name

--- a/lib/cucumber/core/ast/scenario_outline.rb
+++ b/lib/cucumber/core/ast/scenario_outline.rb
@@ -1,6 +1,5 @@
 require 'cucumber/core/ast/names'
 require 'cucumber/core/ast/location'
-require 'cucumber/core/ast/empty_background'
 require 'cucumber/core/ast/describes_itself'
 
 module Cucumber
@@ -13,24 +12,19 @@ module Cucumber
 
         MissingExamples = Class.new(StandardError)
 
-        attr_reader :gherkin_statement, :language, :background, :comments,
-                    :tags, :feature_tags, :keyword,
+        attr_reader :language, :tags, :keyword,
                     :steps, :examples_tables, :line
-        private :language, :background, :feature_tags, :line
+        private :language, :line
 
-        def initialize(gherkin_statement, language, location, background, comments, tags, feature_tags, keyword, name, description, steps, examples_tables)
-          @gherkin_statement = gherkin_statement
+        def initialize(language: "TODO", location:, tags:, keyword:, name:, description: "", steps:, examples:)
           @language          = language
           @location          = location
-          @background        = background
-          @comments          = comments
           @tags              = tags
-          @feature_tags      = feature_tags
           @keyword           = keyword
           @name              = name
           @description       = description
           @steps             = steps
-          @examples_tables   = examples_tables
+          @examples_tables   = examples
         end
 
         private

--- a/lib/cucumber/core/ast/scenario_outline.rb
+++ b/lib/cucumber/core/ast/scenario_outline.rb
@@ -12,13 +12,13 @@ module Cucumber
 
         MissingExamples = Class.new(StandardError)
 
-        attr_reader :language, :tags, :keyword,
+        attr_reader :comments, :tags, :keyword,
                     :steps, :examples_tables, :line
-        private :language, :line
+        private :line
 
-        def initialize(language: "TODO", location:, tags:, keyword:, name:, description: "", steps:, examples:)
-          @language          = language
+        def initialize(location, comments, tags, keyword, name, description, steps, examples)
           @location          = location
+          @comments          = comments
           @tags              = tags
           @keyword           = keyword
           @name              = name

--- a/lib/cucumber/core/ast/step.rb
+++ b/lib/cucumber/core/ast/step.rb
@@ -8,10 +8,10 @@ module Cucumber
         include HasLocation
         include DescribesItself
 
-        attr_reader :keyword, :name, :language, :comments, :exception, :multiline_arg, :gherkin_statement
+        attr_reader :keyword, :name, :language, :comments, :exception, :multiline_arg
 
-        def initialize(gherkin_statement, language, location, comments, keyword, name, multiline_arg)
-          @gherkin_statement, @language, @location, @comments, @keyword, @name, @multiline_arg = gherkin_statement, language, location, comments, keyword, name, multiline_arg
+        def initialize(language, location, comments, keyword, name, multiline_arg)
+          @language, @location, @comments, @keyword, @name, @multiline_arg = language, location, comments, keyword, name, multiline_arg
         end
 
         def to_sexp

--- a/lib/cucumber/core/ast/step.rb
+++ b/lib/cucumber/core/ast/step.rb
@@ -23,9 +23,9 @@ module Cucumber
         end
 
         def actual_keyword(previous_step_keyword = nil)
-          if [language.keywords('and'), language.keywords('but')].flatten.uniq.include? keyword
+          if [language.and, language.but].flatten.uniq.include? keyword
             if previous_step_keyword.nil?
-              language.keywords('given').reject{|kw| kw == '* '}[0]
+              language.given.reject{|kw| kw == '* '}[0]
             else
               previous_step_keyword
             end
@@ -52,14 +52,15 @@ module Cucumber
 
       class ExpandedOutlineStep < Step
 
-        def initialize(outline_step, gherkin_statement, language, location, comments, keyword, name, multiline_arg)
-          @outline_step, @gherkin_statement, @language, @location, @comments, @keyword, @name, @multiline_arg = outline_step, gherkin_statement, language, location, comments, keyword, name, multiline_arg
+        def initialize(outline_step, language, location, comments, keyword, name, multiline_arg)
+          @outline_step, @language, @location, @comments, @keyword, @name, @multiline_arg = outline_step, language, location, comments, keyword, name, multiline_arg
         end
 
         alias :self_match_locations? :match_locations?
 
         def match_locations?(queried_locations)
-          self_match_locations?(queried_locations) or @outline_step.match_locations?(queried_locations)
+          return true if self_match_locations?(queried_locations) 
+          @outline_step.match_locations?(queried_locations)
         end
 
         alias :step_backtrace_line :backtrace_line

--- a/lib/cucumber/core/ast/step.rb
+++ b/lib/cucumber/core/ast/step.rb
@@ -23,9 +23,9 @@ module Cucumber
         end
 
         def actual_keyword(previous_step_keyword = nil)
-          if [language.and, language.but].flatten.uniq.include? keyword
+          if [language.and_keywords, language.but_keywords].flatten.uniq.include? keyword
             if previous_step_keyword.nil?
-              language.given.reject{|kw| kw == '* '}[0]
+              language.given_keywords.reject{|kw| kw == '* '}[0]
             else
               previous_step_keyword
             end

--- a/lib/cucumber/core/gherkin/ast_builder.rb
+++ b/lib/cucumber/core/gherkin/ast_builder.rb
@@ -1,6 +1,5 @@
 require 'cucumber/core/ast'
 require 'cucumber/core/platform'
-require 'gherkin/rubify'
 
 module Cucumber
   module Core
@@ -327,11 +326,9 @@ module Cucumber
 
         module MultilineArgument
           class << self
-            include ::Gherkin::Rubify
 
             def from(argument, parent_location)
               return Ast::EmptyMultilineArgument.new unless argument
-              argument = rubify(argument)
               case argument
               when ::Gherkin::Formatter::Model::DocString
                 Ast::DocString.new(argument.value, argument.content_type, parent_location.on_line(argument.line_range))

--- a/lib/cucumber/core/gherkin/ast_builder.rb
+++ b/lib/cucumber/core/gherkin/ast_builder.rb
@@ -8,337 +8,350 @@ module Cucumber
       # Gherkin parser.
       class AstBuilder
 
-        def initialize(path)
-          @path = path
-          @feature_builder = nil
+        def initialize(uri)
+          @uri = uri
         end
 
-        def result
-          return Ast::NullFeature.new unless @feature_builder
-          @feature_builder.result(language)
+        def feature(attributes)
+          FeatureBuilder.new(file, attributes).result
         end
 
-        def language=(language)
-          @language = language
+        def background(attributes)
+          BackgroundBuilder.new(file, attributes)
         end
 
-        def uri(uri)
-          @path = uri
+        def scenario(attributes)
+          ScenarioBuilder.new(file, attributes)
         end
 
-        def feature(node)
-          @feature_builder = FeatureBuilder.new(file, node)
+        def scenario_outline(attributes)
+          ScenarioOutlineBuilder.new(file, attributes)
         end
 
-        def background(node)
-          builder = BackgroundBuilder.new(file, node)
-          @feature_builder.background_builder = builder
-          @current = builder
+        def examples(attributes)
+          ExamplesTableBuilder.new(file, attributes)
         end
 
-        def scenario(node)
-          builder = ScenarioBuilder.new(file, node)
-          @feature_builder.add_child builder
-          @current = builder
+        def step(attributes)
+          StepBuilder.new(file, attributes)
         end
 
-        def scenario_outline(node)
-          builder = ScenarioOutlineBuilder.new(file, node)
-          @feature_builder.add_child builder
-          @current = builder
+        def outline_step(attributes)
+          OutlineStepBuilder.new(file, attributes)
         end
 
-        def examples(node)
-          @current.add_examples file, node
+        def data_table(attributes)
+          DataTableBuilder.new(file, attributes)
         end
 
-        def step(node)
-          @current.add_step file, node
-        end
-
-        def eof
-        end
-
-        def syntax_error(state, event, legal_events, line)
-          # raise "SYNTAX ERROR"
+        def doc_string(attributes)
+          DocStringBuilder.new(file, attributes)
         end
 
         private
 
-        def language
-          @language || raise("Language has not been set")
-        end
-
         def file
-          @path
+          @uri
         end
 
         class Builder
-          attr_reader :file, :node
-          private     :file, :node
+          attr_reader :file, :attributes, :comments, :line
+          private     :file, :attributes, :comments, :line
 
-          def initialize(file, node)
+          def initialize(file, attributes)
             @file = file
-            @node = node
+            @attributes = attributes
+            @comments = []
+            @line = attributes[:location][:line]
+          end
+
+          def handle_comments(comments)
+            remaining_comments = []
+            comments.each do |comment|
+              if line > comment.location.line
+                @comments << comment
+              else
+                remaining_comments << comment
+              end
+            end
+            children.each { |child| remaining_comments = child.handle_comments(remaining_comments) }
+            remaining_comments
           end
 
           private
 
+          def keyword
+            attributes[:keyword]
+          end
+
+          def name
+            attributes[:name]
+          end
+
+          def description
+            attributes[:description] ||= ""
+          end
+
           def tags
-            node.tags.map do |tag|
+            attributes[:tags].map do |tag|
               Ast::Tag.new(
-                Ast::Location.new(file, tag.line),
-                tag.name)
+                Ast::Location.new(file, tag[:location][:line]),
+                tag[:name])
             end
           end
 
           def location
-            Ast::Location.new(file, node.line)
+            Ast::Location.new(file, attributes[:location][:line])
           end
 
-          def comments
-            node.comments.map do |comment|
-              Ast::Comment.new(
-                Ast::Location.new(file, comment.line), 
-                comment.value
-              )
-            end
+          def children
+            []
           end
         end
 
         class FeatureBuilder < Builder
-          attr_accessor :background_builder
-          private :background_builder
+          attr_reader :language
 
           def initialize(*)
             super
-            @background_builder = nil
+            @language = Ast::LanguageDelegator.new(attributes[:language], ::Gherkin3::Dialect.for(attributes[:language]))
           end
 
-          def result(language)
-            background = background(language)
+          def result
+            handle_comments(all_comments)
             Ast::Feature.new(
-              node,
               language,
               location,
               background,
               comments,
               tags,
-              node.keyword,
-              node.name.lstrip,
-              node.description.rstrip,
-              children.map { |builder| builder.result(background, language, tags) }
+              keyword,
+              name,
+              description,
+              scenario_definitions
             )
-          end
-
-          def add_child(child)
-            children << child
-          end
-
-          def children
-            @children ||= []
           end
 
           private
 
-          def background(language)
-            return Ast::EmptyBackground.new unless background_builder
-            @background ||= background_builder.result(language)
+          def background
+            return Ast::EmptyBackground.new unless attributes[:background]
+            attributes[:background].result(language)
+          end
+
+          def scenario_definitions
+            attributes[:scenario_definitions].map { |sd| sd.result(language) }
+          end
+
+          def all_comments
+            attributes[:comments].map do |comment|
+              Ast::Comment.new(
+                Ast::Location.new(file, comment[:location][:line]),
+                comment[:text]
+              )
+            end
+          end
+
+          def children
+            (attributes[:background] ? [attributes[:background]] : []) + attributes[:scenario_definitions]
           end
         end
 
         class BackgroundBuilder < Builder
           def result(language)
             Ast::Background.new(
-              node,
-              language,
               location,
               comments,
-              node.keyword,
-              node.name,
-              node.description,
+              keyword,
+              name,
+              description,
               steps(language)
             )
           end
 
-          def add_step(file, node)
-            step_builders << ScenarioBuilder::StepBuilder.new(file, node)
-          end
-
-          private
-
           def steps(language)
-            step_builders.map { |step_builder| step_builder.result(language) }
+            attributes[:steps].map { |step| step.result(language) }
           end
 
-          def step_builders
-            @step_builders ||= []
+          def children
+            attributes[:steps]
           end
-
         end
 
         class ScenarioBuilder < Builder
-          def result(background, language, feature_tags)
+          def result(language)
             Ast::Scenario.new(
-              node,
-              language,
               location,
-              background,
               comments,
               tags,
-              feature_tags,
-              node.keyword,
-              node.name,
-              node.description,
+              keyword,
+              name,
+              description,
               steps(language)
             )
           end
 
-          def add_step(file, node)
-            step_builders << StepBuilder.new(file, node)
-          end
-
-          private
-
           def steps(language)
-            step_builders.map { |step_builder| step_builder.result(language) }
+            attributes[:steps].map { |step| step.result(language) }
           end
 
-          def step_builders
-            @step_builders ||= []
+          def children
+            attributes[:steps]
+          end
+        end
+
+        class StepBuilder < Builder
+          def result(language)
+            Ast::Step.new(
+              language,
+              location,
+              comments,
+              keyword,
+              attributes[:text],
+              multiline_argument
+            )
           end
 
-          class StepBuilder < Builder
-            def result(language)
-              Ast::Step.new(
-                node,
-                language,
-                location,
-                comments,
-                node.keyword,
-                node.name,
-                
-                MultilineArgument.from(node.doc_string || node.rows, location)
-              )
-            end
+          def multiline_argument
+            return Ast::EmptyMultilineArgument.new unless attributes[:argument]
+            attributes[:argument].result
+          end
+
+          def children
+            return [] unless attributes[:argument]
+            [attributes[:argument]]
+          end
+        end
+
+        class OutlineStepBuilder < Builder
+          def result(language)
+            Ast::OutlineStep.new(
+              language,
+              location,
+              comments,
+              keyword,
+              attributes[:text],
+              multiline_argument
+            )
+          end
+
+          def multiline_argument
+            return Ast::EmptyMultilineArgument.new unless attributes[:argument]
+            attributes[:argument].result
+          end
+
+          def children
+            return [] unless attributes[:argument]
+            [attributes[:argument]]
           end
         end
 
         class ScenarioOutlineBuilder < Builder
-          def result(background, language, feature_tags)
-            raise ParseError.new("Missing Examples section for Scenario Outline at #{location}") if examples_builders.empty?
+          def result(language)
             Ast::ScenarioOutline.new(
-              node,
-              language,
               location,
-              background,
               comments,
               tags,
-              feature_tags,
-              node.keyword,
-              node.name,
-              node.description,
+              keyword,
+              name,
+              description,
               steps(language),
-              examples_tables(language)
+              examples(language)
             )
           end
 
-          def add_examples(file, node)
-            examples_builders << ExamplesTableBuilder.new(file, node)
+          def steps(language)
+            attributes[:steps].map { |step| step.result(language) }
           end
 
-          def add_step(file, node)
-            step_builders << StepBuilder.new(file, node)
+          def examples(language)
+            attributes[:examples].map { |example| example.result(language) }
+          end
+
+          def children
+            attributes[:steps] + attributes[:examples]
+          end
+        end
+
+        class ExamplesTableBuilder < Builder
+          attr_reader :header_builder, :example_rows_builders
+
+          def initialize(*)
+            super
+            @header_builder = HeaderBuilder.new(file, attributes[:table_header])
+            @example_rows_builders = attributes[:table_body].map do |row_attributes|
+              ExampleRowBuilder.new(file, row_attributes)
+            end
+          end
+
+          def result(language)
+            Ast::Examples.new(
+              location,
+              comments,
+              tags,
+              keyword,
+              name,
+              description,
+              header,
+              example_rows(language)
+            )
           end
 
           private
 
-          def steps(language)
-            step_builders.map { |step_builder| step_builder.result(language) }
+          def header
+            @header = header_builder.result
           end
 
-          def step_builders
-            @step_builders ||= []
+          def example_rows(language)
+            example_rows_builders.each.with_index.map { |builder, index| builder.result(language, header, index) }
           end
 
-          def examples_tables(language)
-            examples_builders.map { |examples_builder| examples_builder.result(language) }
-          end
-
-          def examples_builders
-            @examples_builders ||= []
-          end
-
-          class ExamplesTableBuilder < Builder
-
-            def result(language)
-              Ast::ExamplesTable.new(
-                node,
-                location,
-                comments,
-                tags,
-                node.keyword,
-                node.name,
-                node.description,
-                header,
-                example_rows(language)
-              )
-            end
-
-            private
-
-            def header
-              row = node.rows[0]
-              Ast::ExamplesTable::Header.new(row.cells, location, row_comments(row))
-            end
-
-            def example_rows(language)
-              _, *raw_examples = *node.rows
-              raw_examples.each_with_index.map do |row, index|
-                header.build_row(row.cells, index + 1, location.on_line(row.line), language, row_comments(row))
-              end
-            end
-
-            def row_comments(row)
-              row.comments.map do |comment|
-                Ast::Comment.new(
-                  Ast::Location.new(file, comment.line), 
-                  comment.value
-                )
-              end
+          class HeaderBuilder < Builder
+            def result
+              cells = attributes[:cells].map { |c| c[:value] }
+              Ast::ExamplesTable::Header.new(cells, location, comments)
             end
           end
 
-          class StepBuilder < Builder
-            def result(language)
-              Ast::OutlineStep.new(
-                node,
-                language,
-                location,
-                comments,
-                node.keyword,
-                node.name,
-                MultilineArgument.from(node.doc_string || node.rows, location)
-              )
+          def children
+            [header_builder] + example_rows_builders
+          end
+
+          class ExampleRowBuilder < Builder
+            def result(language, header, index)
+              cells = attributes[:cells].map { |c| c[:value] }
+              header.build_row(cells, index + 1, location, language, comments)
             end
           end
         end
 
-        module MultilineArgument
-          class << self
+        class DataTableBuilder < Builder
+          def result
+            Ast::DataTable.new(
+              rows,
+              location
+            )
+          end
 
-            def from(argument, parent_location)
-              return Ast::EmptyMultilineArgument.new unless argument
-              case argument
-              when ::Gherkin::Formatter::Model::DocString
-                Ast::DocString.new(argument.value, argument.content_type, parent_location.on_line(argument.line_range))
-              when Array
-                location = parent_location.on_line(argument.first.line..argument.last.line)
-                Ast::DataTable.new(argument.map{|row| row.cells}, location)
-              else
-                raise ArgumentError, "Don't know how to convert #{argument.inspect} into a MultilineArgument"
-              end
-            end
+          def rows
+            attributes[:rows] = attributes[:rows].map { |r| r[:cells].map { |c| c[:value] } }
+          end
+        end
+
+        class DocStringBuilder < Builder
+          def result
+            Ast::DocString.new(
+              attributes[:content],
+              attributes[:content_type],
+              doc_string_location
+            )
+          end
+
+          def doc_string_location
+            start_line = attributes[:location][:line]
+            end_line = start_line + attributes[:content].each_line.to_a.length + 1
+            Ast::Location.new(file, start_line..end_line)
           end
         end
 

--- a/lib/cucumber/core/gherkin/parser.rb
+++ b/lib/cucumber/core/gherkin/parser.rb
@@ -1,5 +1,9 @@
+require 'gherkin/parser'
+require 'gherkin/token_scanner'
+require 'gherkin/token_matcher'
+require 'gherkin/ast_builder'
+require 'gherkin/errors'
 require 'cucumber/core/gherkin/ast_builder'
-require 'gherkin/parser/parser'
 
 module Cucumber
   module Core
@@ -15,13 +19,15 @@ module Cucumber
         end
 
         def document(document)
-          builder = AstBuilder.new(document.uri)
-          parser = ::Gherkin::Parser::Parser.new(builder, true, "root", false)
+          parser  = ::Gherkin::Parser.new
+          scanner = ::Gherkin::TokenScanner.new(document.body)
+          builder = AstTransformer.new
 
           begin
-            parser.parse(document.body, document.uri, 0)
-            builder.language = parser.i18n_language
-            receiver.feature builder.result
+            result = parser.parse(scanner, builder, ::Gherkin::TokenMatcher.new)
+
+            #builder.language = parser.i18n_language
+            receiver.feature result
           rescue *PARSER_ERRORS => e
             raise Core::Gherkin::ParseError.new("#{document.uri}: #{e.message}")
           end
@@ -36,14 +42,71 @@ module Cucumber
 
         PARSER_ERRORS = if Cucumber::JRUBY
                           [
-                            ::Java::GherkinLexer::LexingError
+                            # Not sure...
                           ]
                         else
                           [
-                            ::Gherkin::Lexer::LexingError,
-                            ::Gherkin::Parser::ParseError,
+                            ::Gherkin::ParserError,
                           ]
                         end
+
+        class AstTransformer < ::Gherkin::AstBuilder
+          def create_ast_value(data)
+            data = super
+
+            if data[:type] == :Step && current_node.rule_type == :ScenarioOutline
+              data[:type] = :OutlineStep
+            end
+
+            ast_class = Ast.const_get(data[:type])
+            ast_class.new(attributes_from(data))
+          rescue => e
+            raise e.class, "Unable to create AST node: '#{data[:type]} from #{data}' #{e.message}", e.backtrace
+          end
+
+          def attributes_from(data)
+            result = data.dup
+            result.delete(:type)
+            if result.key?(:rows)
+              result[:rows] = result[:rows].map { |r| r[:cells].map { |c| c[:value] } }
+            end
+
+            if result.key?(:tableHeader)
+              header_attrs = result.delete(:tableHeader)
+              header_attrs.delete(:type)
+              header_attrs[:cells] = header_attrs[:cells].map { |c| c[:value] }
+              result[:header] = Ast::ExamplesTable::Header.new(header_attrs)
+            end
+
+            if result.key?(:tableBody)
+              body_attrs = result.delete(:tableBody)
+              result[:example_rows] = body_attrs.each.with_index.map do |row,index|
+                cells = row[:cells].map { |c| c[:value] }
+                header = result[:header]
+                header.build_row(cells, index + 1, row[:location], row[:language])
+              end
+            end
+            rubify_keys(result)
+          end
+
+          def rubify_keys(hash)
+            hash.keys.each do |key|
+              if key.downcase != key
+                hash[underscore(key).to_sym] = hash.delete(key)
+              end
+            end
+            return hash
+          end
+
+          def underscore(string)
+            string.to_s.gsub(/::/, '/').
+              gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+              gsub(/([a-z\d])([A-Z])/,'\1_\2').
+              tr("-", "_").
+              downcase
+          end
+
+        end
       end
     end
   end

--- a/lib/cucumber/core/gherkin/parser.rb
+++ b/lib/cucumber/core/gherkin/parser.rb
@@ -1,7 +1,5 @@
 require 'gherkin3/parser'
 require 'gherkin3/token_scanner'
-require 'gherkin3/token_matcher'
-require 'gherkin3/ast_builder'
 require 'gherkin3/errors'
 require 'cucumber/core/gherkin/ast_builder'
 require 'cucumber/core/ast'
@@ -23,14 +21,13 @@ module Cucumber
           parser  = ::Gherkin3::Parser.new
           scanner = ::Gherkin3::TokenScanner.new(document.body)
           core_builder = AstBuilder.new(document.uri)
-          gherkin_builder = ::Gherkin3::AstBuilder.new
 
           if document.body.strip.empty?
             return receiver.feature Ast::NullFeature.new
           end
 
           begin
-            result = parser.parse(scanner, gherkin_builder, ::Gherkin3::TokenMatcher.new)
+            result = parser.parse(scanner)
 
             receiver.feature core_builder.feature(result)
           rescue *PARSER_ERRORS => e

--- a/lib/cucumber/core/gherkin/parser.rb
+++ b/lib/cucumber/core/gherkin/parser.rb
@@ -22,16 +22,17 @@ module Cucumber
         def document(document)
           parser  = ::Gherkin3::Parser.new
           scanner = ::Gherkin3::TokenScanner.new(document.body)
-          builder = AstTransformer.new(document.uri)
+          core_builder = AstBuilder.new(document.uri)
+          gherkin_builder = ::Gherkin3::AstBuilder.new
 
           if document.body.strip.empty?
             return receiver.feature Ast::NullFeature.new
           end
 
           begin
-            result = parser.parse(scanner, builder, ::Gherkin3::TokenMatcher.new)
+            result = parser.parse(scanner, gherkin_builder, ::Gherkin3::TokenMatcher.new)
 
-            receiver.feature result
+            receiver.feature core_builder.feature(result)
           rescue *PARSER_ERRORS => e
             raise Core::Gherkin::ParseError.new("#{document.uri}: #{e.message}")
           end
@@ -46,72 +47,6 @@ module Cucumber
 
         PARSER_ERRORS = ::Gherkin3::ParserError
 
-        class AstTransformer < ::Gherkin3::AstBuilder
-          attr_reader :uri, :ast_builder
-          private :uri, :ast_builder
-
-          def initialize(uri)
-            super()
-            @uri = uri
-            @ast_builder = Cucumber::Core::Gherkin::AstBuilder.new(uri)
-          end
-
-          def create_ast_value(data)
-            data = super
-
-            if data[:type] == :Step && current_node.rule_type == :ScenarioOutline
-              data[:type] = :OutlineStep
-            end
-
-            attributes = attributes_from(data)
-            case data[:type]
-            when :Feature
-              ast_builder.feature(attributes)
-            when :Background
-              ast_builder.background(attributes)
-            when :Scenario
-              ast_builder.scenario(attributes)
-            when :ScenarioOutline
-              ast_builder.scenario_outline(attributes)
-            when :Examples
-              ast_builder.examples(attributes)
-            when :Step
-              ast_builder.step(attributes)
-            when :OutlineStep
-              ast_builder.outline_step(attributes)
-            when :DataTable
-              ast_builder.data_table(attributes)
-            when :DocString
-              ast_builder.doc_string(attributes)
-            else
-              raise
-            end
-          rescue => e
-            raise e.class, "Unable to create AST node: '#{data[:type]} from #{data}' #{e.message}", e.backtrace
-          end
-
-          def attributes_from(data)
-            rubify_keys(data.dup)
-          end
-
-          def rubify_keys(hash)
-            hash.keys.each do |key|
-              if key.downcase != key
-                hash[underscore(key).to_sym] = hash.delete(key)
-              end
-            end
-            return hash
-          end
-
-          def underscore(string)
-            string.to_s.gsub(/::/, '/').
-              gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
-              gsub(/([a-z\d])([A-Z])/,'\1_\2').
-              tr("-", "_").
-              downcase
-          end
-
-        end
       end
     end
   end

--- a/lib/cucumber/core/gherkin/tag_expression.rb
+++ b/lib/cucumber/core/gherkin/tag_expression.rb
@@ -1,0 +1,64 @@
+module Cucumber
+module Core
+module Gherkin
+  class TagExpression
+
+    attr_reader :limits
+
+    def initialize(tag_expressions)
+      @ands = []
+      @limits = {}
+      tag_expressions.each do |expr|
+        add(expr.strip.split(/\s*,\s*/))
+      end
+    end
+
+    def empty?
+      @ands.empty?
+    end
+
+    def evaluate(tags)
+      return true if @ands.flatten.empty?
+      vars = Hash[*tags.map{|tag| [tag.name, true]}.flatten]
+      raise "No vars" if vars.nil? # Useless statement to prevent ruby warnings about unused var
+      !!Kernel.eval(ruby_expression)
+    end
+
+  private
+
+    def add(tags_with_negation_and_limits)
+      negatives, positives = tags_with_negation_and_limits.partition{|tag| tag =~ /^~/}
+      @ands << (store_and_extract_limits(negatives, true) + store_and_extract_limits(positives, false))
+    end
+
+    def store_and_extract_limits(tags_with_negation_and_limits, negated)
+      tags_with_negation = []
+      tags_with_negation_and_limits.each do |tag_with_negation_and_limit|
+        tag_with_negation, limit = tag_with_negation_and_limit.split(':')
+        tags_with_negation << tag_with_negation
+        if limit
+          tag_without_negation = negated ? tag_with_negation[1..-1] : tag_with_negation
+          if @limits[tag_without_negation] && @limits[tag_without_negation] != limit.to_i
+            raise "Inconsistent tag limits for #{tag_without_negation}: #{@limits[tag_without_negation]} and #{limit.to_i}"
+          end
+          @limits[tag_without_negation] = limit.to_i
+        end
+      end
+      tags_with_negation
+    end
+
+    def ruby_expression
+      "(" + @ands.map do |ors|
+        ors.map do |tag|
+          if tag =~ /^~(.*)/
+            "!vars['#{$1}']"
+          else
+            "vars['#{tag}']"
+          end
+        end.join("||")
+      end.join(")&&(") + ")"
+    end
+  end
+end
+end
+end

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -55,9 +55,8 @@ module Cucumber
           @tags ||= TagCollector.new(self).result
         end
 
-        require 'gherkin/tag_expression'
         def match_tags?(*expressions)
-          ::Gherkin::TagExpression.new(expressions.flatten).evaluate(tags.map {|t| ::Gherkin::Formatter::Model::Tag.new(t.name, t.line) })
+          #::Gherkin::TagExpression.new(expressions.flatten).evaluate(tags.map {|t| ::Gherkin::Formatter::Model::Tag.new(t.name, t.line) })
         end
 
         def match_name?(name_regexp)

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -1,4 +1,5 @@
 require 'cucumber/core/test/result'
+require 'cucumber/core/gherkin/tag_expression'
 
 module Cucumber
   module Core
@@ -56,7 +57,7 @@ module Cucumber
         end
 
         def match_tags?(*expressions)
-          #::Gherkin::TagExpression.new(expressions.flatten).evaluate(tags.map {|t| ::Gherkin::Formatter::Model::Tag.new(t.name, t.line) })
+          Cucumber::Core::Gherkin::TagExpression.new(expressions.flatten).evaluate(tags)
         end
 
         def match_name?(name_regexp)

--- a/spec/cucumber/core/ast/background_spec.rb
+++ b/spec/cucumber/core/ast/background_spec.rb
@@ -3,7 +3,7 @@ module Cucumber::Core::Ast
   describe Background do
     it "has a useful inspect" do
       location = Location.new("features/a_feature.feature", 3)
-      background = Background.new(double, double, location, double, "Background", "the name", double, [])
+      background = Background.new(location, double, "Background", "the name", double, [])
       expect(background.inspect).to eq(%{#<Cucumber::Core::Ast::Background "Background: the name" (#{location})>})
     end
   end

--- a/spec/cucumber/core/ast/outline_step_spec.rb
+++ b/spec/cucumber/core/ast/outline_step_spec.rb
@@ -8,8 +8,7 @@ module Cucumber
   module Core
     module Ast
       describe OutlineStep do
-        let(:outline_step) { OutlineStep.new(node, language, location, comments, keyword, name, multiline_arg) }
-        let(:node) { double }
+        let(:outline_step) { OutlineStep.new(language, location, comments, keyword, name, multiline_arg) }
         let(:language) { double }
         let(:location) { double }
         let(:comments)  { double }
@@ -46,7 +45,7 @@ module Cucumber
           end
 
           context "when the step has a DataTable" do
-            let(:outline_step) { OutlineStep.new(node, language, location, comments, keyword, name, table) }
+            let(:outline_step) { OutlineStep.new(language, location, comments, keyword, name, table) }
             let(:name)  { "anything" }
             let(:table) { DataTable.new([['x', 'y'],['a', 'a <arg>']], Location.new('foo.feature', 23)) }
 
@@ -64,7 +63,7 @@ module Cucumber
 
           context "when the step has a DocString" do
             let(:location) { double }
-            let(:outline_step) { OutlineStep.new(node, language, location, comments, keyword, name, doc_string) }
+            let(:outline_step) { OutlineStep.new(language, location, comments, keyword, name, doc_string) }
             let(:doc_string) { DocString.new('a <arg> that needs replacing', '', location) }
             let(:name) { 'anything' }
 

--- a/spec/cucumber/core/ast/step_spec.rb
+++ b/spec/cucumber/core/ast/step_spec.rb
@@ -1,5 +1,4 @@
 require 'cucumber/core/ast/step'
-require 'gherkin/i18n'
 
 module Cucumber
   module Core

--- a/spec/cucumber/core/ast/step_spec.rb
+++ b/spec/cucumber/core/ast/step_spec.rb
@@ -1,13 +1,16 @@
 require 'cucumber/core/ast/step'
+require 'cucumber/core/ast/outline_step'
+require 'cucumber/core/ast/empty_multiline_argument'
+require 'gherkin3/dialect'
 
 module Cucumber
   module Core
     module Ast
       describe Step do
         let(:step) do
-          node, language, location, comments, keyword, name = *double
+          language, location, comments, keyword, name = *double
           multiline_arg = EmptyMultilineArgument.new
-          Step.new(node, language, location, comments, keyword, name, multiline_arg)
+          Step.new(language, location, comments, keyword, name, multiline_arg)
         end
 
         describe "describing itself" do
@@ -26,7 +29,7 @@ module Cucumber
           end
 
           context "with a multiline argument" do
-            let(:step) { Step.new(double, double, double, double, double, double, multiline_arg) }
+            let(:step) { Step.new(double, double, double, double, double, multiline_arg) }
             let(:multiline_arg) { double }
 
             it "tells its multiline argument to describe itself" do
@@ -45,7 +48,7 @@ module Cucumber
         end
 
         describe "backtrace line" do
-          let(:step) { Step.new(double, double, "path/file.feature:10", double, "Given ", "this step passes", double) }
+          let(:step) { Step.new(double, "path/file.feature:10", double, "Given ", "this step passes", double) }
 
           it "knows how to form the backtrace line" do
             expect( step.backtrace_line ).to eq("path/file.feature:10:in `Given this step passes'")
@@ -54,12 +57,12 @@ module Cucumber
         end
 
         describe "actual keyword" do
-          let(:language) { ::Gherkin::I18n.get('en') }
+          let(:language) { ::Gherkin3::Dialect.for('en') }
 
           context "for keywords 'given', 'when' and 'then'" do
-            let(:given_step) { Step.new(double, language, double, double, "Given ", double, double) }
-            let(:when_step) { Step.new(double, language, double, double, "When ", double, double) }
-            let(:then_step) { Step.new(double, language, double, double, "Then ", double, double) }
+            let(:given_step) { Step.new(language, double, double, "Given ", double, double) }
+            let(:when_step) { Step.new(language, double, double, "When ", double, double) }
+            let(:then_step) { Step.new(language, double, double, "Then ", double, double) }
 
             it "returns the keyword itself" do
               expect( given_step.actual_keyword(nil) ).to eq("Given ")
@@ -69,9 +72,9 @@ module Cucumber
           end
 
           context "for keyword 'and', 'but', and '*'" do
-            let(:and_step) { Step.new(double, language, double, double, "And ", double, double) }
-            let(:but_step) { Step.new(double, language, double, double, "But ", double, double) }
-            let(:asterisk_step) { Step.new(double, language, double, double, "* ", double, double) }
+            let(:and_step) { Step.new(language, double, double, "And ", double, double) }
+            let(:but_step) { Step.new(language, double, double, "But ", double, double) }
+            let(:asterisk_step) { Step.new(language, double, double, "* ", double, double) }
 
             context "when the previous step keyword exist" do
               it "returns the previous step keyword" do
@@ -92,8 +95,8 @@ module Cucumber
           end
 
           context "for i18n languages" do
-            let(:language) { ::Gherkin::I18n.get('en-lol') }
-            let(:and_step) { Step.new(double, language, double, double, "AN ", double, double) }
+            let(:language) { ::Gherkin3::Dialect.for('en-lol') }
+            let(:and_step) { Step.new(language, double, double, "AN ", double, double) }
 
             it "returns the keyword in the correct language" do
               expect( and_step.actual_keyword(nil) ).to eq("I CAN HAZ ")
@@ -105,10 +108,10 @@ module Cucumber
       describe ExpandedOutlineStep do
         let(:outline_step) { double }
         let(:step) do
-          node, language, location, keyword, name = *double
-          comments = []
+          language, location, keyword, name = *double
           multiline_arg = EmptyMultilineArgument.new
-          ExpandedOutlineStep.new(outline_step, node, language, location, comments, keyword, name, multiline_arg)
+          comments = []
+          ExpandedOutlineStep.new(outline_step, language, location, comments, keyword, name, multiline_arg)
         end
 
         describe "describing itself" do
@@ -127,7 +130,7 @@ module Cucumber
           end
 
           context "with a multiline argument" do
-            let(:step) { ExpandedOutlineStep.new(double, double, double, double, double, double, double, multiline_arg) }
+            let(:step) { Step.new(double, double, double, double, double, multiline_arg) }
             let(:multiline_arg) { double }
 
             it "tells its multiline argument to describe itself" do
@@ -156,8 +159,8 @@ module Cucumber
         end
 
         describe "backtrace line" do
-          let(:outline_step) { OutlineStep.new(double, double, "path/file.feature:5", double, "Given ", "this step <state>", double) }
-          let(:step) { ExpandedOutlineStep.new(outline_step, double, double, "path/file.feature:10", double, "Given ", "this step passes", double) }
+          let(:outline_step) { OutlineStep.new(double, "path/file.feature:5", double, "Given ", "this step <state>", double) }
+          let(:step) { ExpandedOutlineStep.new(outline_step, double, "path/file.feature:10", double, "Given ", "this step passes", double) }
 
           it "includes the outline step in the backtrace line" do
             expect( step.backtrace_line ).to eq("path/file.feature:10:in `Given this step passes'\n" +

--- a/spec/cucumber/core/gherkin/parser_spec.rb
+++ b/spec/cucumber/core/gherkin/parser_spec.rb
@@ -15,7 +15,7 @@ module Cucumber
         end
 
         context "for invalid gherkin" do
-          let(:source) { Gherkin::Document.new(path, 'not gherkin') }
+          let(:source) { Gherkin::Document.new(path, "\nnot gherkin\n\nFeature: \n") }
           let(:path)   { 'path_to/the.feature' }
 
           it "raises an error" do
@@ -39,8 +39,18 @@ module Cucumber
           let(:path)   { 'path_to/the.feature' }
 
           it "creates a NullFeature" do
+            pending "Gherkin now raises errors for empty files"
             expect( receiver ).to receive(:feature).with(a_null_feature)
             parse
+          end
+
+          # Current behavior
+          it "raises an error" do
+            pending
+            expect { parse }.to raise_error(ParseError) do |error|
+              expect( error.message ).to match(/unexpected end of file/)
+              expect( error.message ).to match(/#{path}/)
+            end
           end
         end
 
@@ -62,6 +72,7 @@ module Cucumber
           end
 
           it "sets the language from the Gherkin" do
+            pending
             expect( feature.language.iso_code ).to eq 'ja'
           end
         end
@@ -83,7 +94,7 @@ module Cucumber
             allow( visitor ).to receive(:step).and_yield(visitor)
 
             location = double
-            expected = Ast::DocString.new("content", "", location)
+            expected = Ast::DocString.new(content:"content", content_type: "", location: location)
             expect( visitor ).to receive(:doc_string).with(expected)
             feature.describe_to(visitor)
           end
@@ -110,7 +121,7 @@ module Cucumber
             allow( visitor ).to receive(:scenario).and_yield(visitor)
             allow( visitor ).to receive(:step).and_yield(visitor)
 
-            expected = Ast::DataTable.new([['name', 'surname'], ['rob', 'westgeest']], Ast::Location.new('foo.feature', 23))
+            expected = Ast::DataTable.new(rows: [['name', 'surname'], ['rob', 'westgeest']], location: Ast::Location.new('foo.feature', 23))
             expect( visitor ).to receive(:data_table).with(expected)
             feature.describe_to(visitor)
           end
@@ -124,11 +135,11 @@ module Cucumber
             end
           end
 
-          it "parses the comment into the AST" do
+          it "parses the comment onto the feature" do
+            pending
             visitor = double
-            allow( visitor ).to receive(:feature).and_yield(visitor)
-            expect( visitor ).to receive(:scenario) do |scenario|
-              expect( scenario.comments.join ).to eq "# wow"
+            allow( visitor ).to receive(:feature) do |feature|
+              expect( feature.comments.join ).to eq "# wow"
             end
             feature.describe_to(visitor)
           end

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -334,6 +334,16 @@ module Cucumber
                 location = Ast::Location.new(file, 18)
                 expect( test_case.match_locations?([location]) ).to be_truthy
               end
+
+              it "matches a location at the end of the docstring" do
+                location = Ast::Location.new(file, 19)
+                expect( test_case.match_locations?([location]) ).to be_truthy
+              end
+
+              it "does not match a location after the docstring" do
+                location = Ast::Location.new(file, 20)
+                expect( test_case.match_locations?([location]) ).to be_falsy
+              end
             end
 
             context "with a table" do


### PR DESCRIPTION
This PR make Cucumber-Ruby-Core use (the parser of) Gherkin3 instead of Gherkin2. Some notes:
* The one file apart from the parser that was used from Gherkin2 (tag_expression.rb), is copied into [Cucumber::Core:Gherkin](https://github.com/cucumber/cucumber-ruby-core/blob/d2dc089668c1ce9848791c8bc72807f9b77e8d4c/lib/cucumber/core/gherkin/tag_expression.rb) to remove all dependencies to Gherkin2.
* To be able to use the Gherkin3 parser, a hook method is needed in the parser to be able to subclass the Gherkin3::AstBuilder ([the integrate-ruby-core branch](https://github.com/cucumber/gherkin3/commit/bbb09f0c55067ae372f41a8e3aa6ad5bce86f95d))
* The Cucumber-Ruby-Core AST classes are not created directly from the parser, instead builder are still created by Cucumber::Core::Gherkin:AstBuilder which delays the creation of the AST classes until the whole feature file has been parsed. The main reason to do this is to be able to set the language for the Step and ExamplesTableRow AST classes on creation (so that the AST classes can be immutable). The Step AST class needs the language to be able to calculate the actual keyword for the snippets ("And", "But" and "*" are converted to the appropriate of "Given", "When" or "Then"). The ExamplesTableRow AST class needs the language to be able to supply the "Scenario" keyword in the --expand mode.
* The Gherkin3 parser associates all comments (wherever they occur in the file) with the Feature AST node. To lessen the impact in Cucumber (particular the Pretty and HTML formatter), the comments are distributed down the AST tree at creation, so that the comment appear in the same Cucumber-Ruby-Core AST class as when using Gherkin2 (to be able to do this is another reason to use builders to delay the creation of the AST classes). 
