### PR TITLE
Allow frontend to store useful data on a step during execution.

### DIFF
--- a/lib/cucumber/core/test/step.rb
+++ b/lib/cucumber/core/test/step.rb
@@ -7,9 +7,14 @@ module Cucumber
       class Step
         attr_reader :source
 
-        def initialize(source, action = Test::UndefinedAction.new(source.last.location))
+        def initialize(source, action = Test::UndefinedAction.new(source.last.location), data = {})
           raise ArgumentError if source.any?(&:nil?)
           @source, @action = source, action
+          @data = data
+        end
+
+        def data(key)
+          @data.fetch(key)
         end
 
         def describe_to(visitor, *args)
@@ -32,7 +37,11 @@ module Cucumber
         end
 
         def with_action(location = nil, &block)
-          self.class.new(source, Test::Action.new(location, &block))
+          self.class.new(source, Test::Action.new(location, &block), @data)
+        end
+
+        def with_data(new_data)
+          self.class.new(source, @action, @data.merge(new_data))
         end
 
         def name

--- a/spec/cucumber/core/test/step_spec.rb
+++ b/spec/cucumber/core/test/step_spec.rb
@@ -87,5 +87,20 @@ module Cucumber::Core::Test
       expect( test_step.action_location ).to eq location
     end
 
+    context "extra data" do
+      let(:match)     { double(:match) }
+      let(:test_step) { Step.new([], double(:action), match: match) }
+
+      it "exposes access to named data" do
+        expect( test_step.data(:match) ).to eq match
+      end
+
+      it "updates with new data" do
+        new_match     = double(:new_match)
+        updated_step  = test_step.with_data(match: new_match)
+
+        expect( updated_step.data(:match) ).to eq new_match
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a straw-man idea to allow us to fix:
cucumber/cucumber-ruby-wire@89642961de7d69ffaa5b3616e45cf3d39230a8b5