### PR TITLE
fix https://github.com/cucumber/cucumber-ruby/issues/901

### DIFF
--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -17,6 +17,20 @@ module Cucumber
           test_steps.count
         end
 
+        def matching_location_indexes(queried_locations)
+          matching = []
+          queried_locations.each_with_index do |location, index|
+            source.any? { |s| s.match_locations?([location]) } &&
+              matching << index
+          end
+          queried_locations.each_with_index do |location, index|
+            next if matching.include? index
+            test_steps.any? { |node| node.match_locations? [location]} &&
+              matching << index
+          end
+          return matching
+        end
+
         def describe_to(visitor, *args)
           visitor.test_case(self, *args) do |child_visitor|
             compose_around_hooks(child_visitor, *args) do


### PR DESCRIPTION
to make it 2+ orders of magnitude faster two things were needed:
1. do not try all locations, only those with matching file name
2. do not order test cases after the fact, put them in proper place from the beginning using matching locations index
3. cache locations lists by file name (this gives little improvement but may help better with even larger number of files)

This is achieved by adding a Test::Case method to return index of matching location so we don't need to figure out later which one exactly the matching location was.

Without the case, trying to run our command line took several hours until I kill. With the above changes it takes around 1minute and 40 seconds to process all files on the command line. FYI cucumber 1.3.19 takes around 10-15 seconds.

As far as my testing goes, it is 1:1 compatible with old implementation. You can see f45d34e470c1 though, where duplicates are avoided and processing is faster. Also another two variants in https://github.com/akostadinov/cucumber-ruby-core/tree/all (total 4 variants) but I think this is best.

Would appreciate if somebody can double check compatibility is retained.