### PR TITLE
Run each test case at most once when using line filters

### DIFF
--- a/spec/cucumber/core/test/filters/locations_filter_spec.rb
+++ b/spec/cucumber/core/test/filters/locations_filter_spec.rb
@@ -205,6 +205,17 @@ module Cucumber::Core
             expect( test_case.match_locations?([location]) ).to be_truthy
           end
         end
+
+        context "with duplicate locations in the filter" do
+          it "matches each test case only once" do
+            location_tc_two = test_case_named('two').location
+            location_tc_one = test_case_named('one').location
+            location_last_step_tc_two = Ast::Location.new(file, 10)
+            filter = Test::LocationsFilter.new([location_tc_two, location_tc_one, location_last_step_tc_two])
+            compile [doc], receiver, [filter]
+            expect(receiver.test_case_locations).to eq [test_case_named('two').location, location_tc_one = test_case_named('one').location]
+          end
+        end
       end
 
       context "for a scenario outline" do


### PR DESCRIPTION
When the locations_filter was created to preserve the filter ordering from the command line when executing the test case (in Cucumber-Ruby-Core v1.1.0/Cucumber-Ruby v2.0.0.rc.4), so that `cucumber path/a_feature.feature:10:5` would result in that the test case of line 10 is executed before the test case of line 5, it had the side effect of allowing each test case to executed more than once when using line filter.

Previously `cucumber path/a_feature.feature:10:10:10` would result in that the test case of line 10 was executed once (as in Cucumber v1.3.x), now it results in the test case of line 10 is executed three times.

I think this is not what we want.

This PR contains a failing test for this problem, it is preferably fixed together with #96.
