### PR TITLE
use monotonic time

### DIFF
--- a/lib/cucumber/core/test/timer.rb
+++ b/lib/cucumber/core/test/timer.rb
@@ -24,8 +24,26 @@ module Cucumber
         private
 
         def time_in_nanoseconds
-          t = Time.now
-          t.to_i * 10 ** 9 + t.nsec
+          MonotonicTime.time_in_nanoseconds
+        end
+
+        module MonotonicTime
+          module_function
+
+          if defined?(Process::CLOCK_MONOTONIC)
+            def time_in_nanoseconds
+              Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+            end
+          elsif (defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby') == 'jruby'
+            def time_in_nanoseconds
+              java.lang.System.nanoTime()
+            end
+          else
+            def time_in_nanoseconds
+              t = Time.now
+              t.to_i * 10 ** 9 + t.nsec
+            end
+          end
         end
       end
     end

--- a/spec/cucumber/core/test/timer_spec.rb
+++ b/spec/cucumber/core/test/timer_spec.rb
@@ -6,10 +6,8 @@ module Cucumber
     module Test
       describe Timer do
         before do
-          time = double
-          allow( Time ).to receive(:now) { time }
-          allow( time ).to receive(:nsec).and_return(946752000, 946752001)
-          allow( time ).to receive(:to_i).and_return(1377009235, 1377009235)
+          allow(Timer::MonotonicTime).to receive(:time_in_nanoseconds)
+                                            .and_return(525702744080000, 525702744080001)
         end
 
         it "returns a Result::Duration object" do


### PR DESCRIPTION
for reasons described in https://github.com/ruby-concurrency/concurrent-ruby/issues/256
closes #101