### PR TITLE
Add with_filtered_backtrace method to unknown result

### DIFF
--- a/lib/cucumber/core/test/result.rb
+++ b/lib/cucumber/core/test/result.rb
@@ -30,6 +30,10 @@ module Cucumber
           def describe_to(visitor, *args)
             self
           end
+
+          def with_filtered_backtrace(filter)
+            self
+          end
         end
 
         class Passed

--- a/spec/cucumber/core/test/result_spec.rb
+++ b/spec/cucumber/core/test/result_spec.rb
@@ -118,6 +118,10 @@ module Cucumber::Core::Test
         result.describe_to(visitor, args)
       end
 
+      it "defines a with_filtered_backtrace method" do
+        expect(result.with_filtered_backtrace(double("filter"))).to eql result
+      end
+
       specify { expect( result.to_sym ).to eq :unknown }
 
       specify { expect( result ).not_to be_passed    }


### PR DESCRIPTION
This pull request adds a `#with_filtered_backtrace` method to `Result::Unknown`, enabling Cucumber to handle empty scenarios more gracefully. Addresses this issue in Cucumber-Ruby: https://github.com/cucumber/cucumber-ruby/issues/967