### PR TITLE
Allow language to be passed into document object

### DIFF
--- a/lib/cucumber/core/gherkin/document.rb
+++ b/lib/cucumber/core/gherkin/document.rb
@@ -3,11 +3,12 @@ module Cucumber
   module Core
     module Gherkin
       class Document
-        attr_reader :uri, :body
+        attr_reader :uri, :body, :language
 
-        def initialize(uri, body)
-          @uri = uri
-          @body = body
+        def initialize(uri, body, language=nil)
+          @uri      = uri
+          @body     = body
+          @language = language || 'en'
         end
 
         def to_s

--- a/lib/cucumber/core/gherkin/parser.rb
+++ b/lib/cucumber/core/gherkin/parser.rb
@@ -18,12 +18,13 @@ module Cucumber
         end
 
         def document(document)
-          parser  = ::Gherkin::Parser.new
-          scanner = ::Gherkin::TokenScanner.new(document.body)
-          core_builder = AstBuilder.new(document.uri)
+          parser        = ::Gherkin::Parser.new
+          scanner       = ::Gherkin::TokenScanner.new(document.body)
+          token_matcher = ::Gherkin::TokenMatcher.new(document.language)
+          core_builder  = AstBuilder.new(document.uri)
 
           begin
-            result = parser.parse(scanner)
+            result = parser.parse(scanner, token_matcher)
 
             receiver.feature core_builder.feature(result)
           rescue *PARSER_ERRORS => e


### PR DESCRIPTION
This is a companion to [this PR](https://github.com/cucumber/cucumber-ruby/pull/989) against cucumber-ruby, which allows language to be passed in as a command line option. It allows the language to be passed into the `Cucumber::Core::Gherkin::Document` object on initialization, and creates a `TokenMatcher` object using that language when parsing the document.