### PR TITLE
Remove support for Ruby v1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: false
 
 rvm:
+  - 2.3.0
   - 2.2
   - 2.1
   - 2.0.0
-  - 1.9.3
-  - jruby
+  - jruby-9.0.5.0
 
 # whitelist
 branches:

--- a/spec/cucumber/core/test/filters/locations_filter_spec.rb
+++ b/spec/cucumber/core/test/filters/locations_filter_spec.rb
@@ -365,6 +365,7 @@ module Cucumber::Core
       end
 
       max_duration_ms = 10000
+      max_duration_ms = max_duration_ms * 2.5 if defined?(JRUBY_VERSION)
       it "filters #{num_features * num_scenarios_per_feature} test cases within #{max_duration_ms}ms" do
         filter = Test::LocationsFilter.new(locations)
         Timeout.timeout(max_duration_ms / 1000.0) do


### PR DESCRIPTION
In practice the only thing to do is to remove ruby v1.9.3 from the Travis matrix.