### PR TITLE
Queue the events in the event bus before the bus is started.

### DIFF
--- a/lib/cucumber/core.rb
+++ b/lib/cucumber/core.rb
@@ -8,7 +8,7 @@ require 'cucumber/core/test/runner'
 module Cucumber
   module Core
 
-    def execute(gherkin_documents, filters = [], event_bus = EventBus.new)
+    def execute(gherkin_documents, filters = [], event_bus = create_and_start_event_bus)
       yield event_bus if block_given?
       receiver = Test::Runner.new(event_bus)
       compile gherkin_documents, receiver, filters
@@ -39,5 +39,10 @@ module Cucumber
       end
     end
 
+    def create_and_start_event_bus
+      event_bus = EventBus.new
+      event_bus.start
+      event_bus
+    end
   end
 end

--- a/spec/cucumber/core/event_bus_spec.rb
+++ b/spec/cucumber/core/event_bus_spec.rb
@@ -18,6 +18,8 @@ module Cucumber
 
       context "broadcasting events" do
 
+        before(:each) { event_bus.start }
+
         it "can broadcast by calling a method named after the event ID" do
           called = false
           event_bus.on(:test_event) {called = true }
@@ -82,7 +84,23 @@ module Cucumber
 
       end
 
+      context "queuing events" do
+
+        it "before the event bus is started, events are queued and broadcasted when started" do
+          called = false
+          event_bus.on(:test_event) {called = true }
+          event_bus.test_event
+          expect(called).to be false
+          event_bus.start
+          expect(called).to be true
+        end
+
+      end
+
       context "subscribing to events" do
+
+        before(:each) { event_bus.start }
+
         it "allows subscription by symbol (Event ID)" do
           received_payload = nil
           event_bus.on(:test_event) do |event|
@@ -138,14 +156,19 @@ module Cucumber
 
       end
 
-      it "will let you inspect the registry" do
-        expect(event_bus.event_types[:test_event]).to eq Events::TestEvent
-      end
+      context "event registry" do
 
-      it "won't let you modify the registry" do
-        expect { event_bus.event_types[:foo] = :bar }.to raise_error(RuntimeError)
-      end
+        before(:each) { event_bus.start }
 
+        it "will let you inspect the registry" do
+          expect(event_bus.event_types[:test_event]).to eq Events::TestEvent
+        end
+
+        it "won't let you modify the registry" do
+          expect { event_bus.event_types[:foo] = :bar }.to raise_error(RuntimeError)
+        end
+
+      end
     end
   end
 end

--- a/spec/cucumber/core/report/summary_spec.rb
+++ b/spec/cucumber/core/report/summary_spec.rb
@@ -16,7 +16,10 @@ module Cucumber::Core::Report
     let(:duration) { double }
     let(:exception) { double }
 
-    before(:each) { @summary = Summary.new(event_bus) }
+    before(:each) do
+      @summary = Summary.new(event_bus)
+      event_bus.start
+    end
 
     context "test case summary" do
       let(:test_case) { double }

--- a/spec/cucumber/core_spec.rb
+++ b/spec/cucumber/core_spec.rb
@@ -201,6 +201,9 @@ module Cucumber
     end
 
     describe "executing a test suite" do
+      let(:event_bus) { Core::EventBus.new }
+
+      before(:each) { event_bus.start }
 
       it "fires events" do
         gherkin = gherkin do
@@ -273,7 +276,6 @@ module Cucumber
             end
           end
 
-          event_bus = Core::EventBus.new
           report = Core::Report::Summary.new(event_bus)
           execute [gherkin], [Core::Test::Filters::ActivateStepsForSelfTest.new], event_bus
 
@@ -317,7 +319,6 @@ module Cucumber
           end
           logger = []
 
-          event_bus = Core::EventBus.new
           report = Core::Report::Summary.new(event_bus)
           execute [gherkin], [WithAroundHooks.new(logger)], event_bus
 
@@ -352,7 +353,6 @@ module Cucumber
           end
         end
 
-        event_bus = Core::EventBus.new
         report = Core::Report::Summary.new(event_bus)
         execute [gherkin], [ Cucumber::Core::Test::TagFilter.new(['@a']) ], event_bus
 
@@ -371,7 +371,6 @@ module Cucumber
           end
         end
 
-        event_bus = Core::EventBus.new
         report = Core::Report::Summary.new(event_bus)
         execute [gherkin], [ Cucumber::Core::Test::NameFilter.new([/scenario/]) ], event_bus
 


### PR DESCRIPTION
## Summary

To avoid that listeners miss events broadcast before the got a change to register themselves with the event bus, the bus needs to queue events until an explicit start message is received.

## Details

Before the `EventBus#start` method has been called, the `EventBus` will queue broadcast events, and then pass them on to the handlers when `EventBus#start` is called.
After the `EventBus#start` method has been called, the `EventBus` immediately pass on broadcast event to the handlers.

## Motivation and Context

Is needed for fix of https://github.com/cucumber/cucumber-ruby/issues/1041, see https://github.com/cucumber/cucumber-ruby/pull/1059.

## How Has This Been Tested?

Rspec specs have been updated to cover the changed functionality.

## Types of changes

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
