### PR TITLE
More versatile row value access.

### DIFF
--- a/lib/cucumber/core/ast/examples_table.rb
+++ b/lib/cucumber/core/ast/examples_table.rb
@@ -82,6 +82,10 @@ module Cucumber
               other.data == data
           end
 
+          def [](parameter_name)
+            @data[parameter_name]
+          end
+
           def values
             @data.values
           end

--- a/spec/cucumber/core/ast/examples_table_spec.rb
+++ b/spec/cucumber/core/ast/examples_table_spec.rb
@@ -75,10 +75,15 @@ module Cucumber::Core::Ast
         end
       end
 
-      describe 'accesing the values' do
+      describe 'accessing the values' do
         it 'returns the actual row values' do
           row = ExamplesTable::Row.new({'x' => '1', 'y' => '2'}, 1, location, language, comments)
           expect( row.values ).to eq ['1', '2']
+        end
+
+        it "can access a row value by it's parameter name" do
+          row = ExamplesTable::Row.new({'x' => '1', 'y' => '2'}, 1, location, language, comments)
+          expect( row['x']).to eq '1'
         end
       end
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Added a method to allow the retrieval of a value in an AST Row by using the example table parameter that corresponds to it.

## Details

`Cucumber::Core::Ast::ExamplesTable::Row` now has a `#[]` method.

## Motivation and Context

I wanted to be able to retrieve a value from a row without having to know ahead of time which position it would be in in the array returned by `#values`. I also didn't want to have to go through the effort of determining the index on the fly by accessing the header object, finding the index of the parameter name and then using that as the index for the value array. I just wanted a way to say "Hey, row! Give me the value that you used for this parameter!"

## How Has This Been Tested?

There's a spec for it.

There were a few failings specs but they were already failing and, given the very narrow nature of my change, are certainly not my fault.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Added a method to allow retrieving a row value by it's corresponding parameter.