### PR TITLE
Add Ruby 2.4.0 as allow_failures for coverage reports warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 sudo: false
 
-before_install:
-  - gem update simplecov
-
 rvm:
   - ruby-head
   - 2.4.0
@@ -15,6 +12,7 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: 2.4.0
   fast_finish: true
 
 # whitelist


### PR DESCRIPTION
## Summary

Only Ruby 2.4.0 is failed on current master branch.
https://travis-ci.org/cucumber/cucumber-ruby-core/jobs/207769607

## Details

```
346 examples, 0 failures

No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.

Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
```

The reason might look "spec:warnings" does not display errors when it includes warnings on Travis.
So, add Ruby 2.4.0 as allow_failures for coverage reports warnings.

## Motivation and Context

I want to fix issue.

## How Has This Been Tested?

Travis tests it.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
