### PR TITLE
Remove Ruby 2.4 from allow_failures in .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: 2.4.0
   fast_finish: true
 
 # whitelist


### PR DESCRIPTION
## Summary

Remove Ruby 2.4 from allow_failures in .travis.yml.

## Details

Because coveralls 0.8.20 for Ruby 2.4 compatibility was released.
See also https://github.com/lemurheavy/coveralls-ruby/pull/117

## Motivation and Context

Want to check on Ruby 2.4.

## How Has This Been Tested?

Travis will test it.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
