### PR TITLE
Travis: jruby-9.1.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2
   - 2.1
   - 2.0.0
-  - jruby-9.1.8.0
+  - jruby-9.1.10.0
 
 matrix:
   allow_failures:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.