### PR TITLE
Define Cucumber::WINDOWS_MODERN for Windows 10 Creators Update

### DIFF
--- a/lib/cucumber/core/platform.rb
+++ b/lib/cucumber/core/platform.rb
@@ -9,7 +9,7 @@ module Cucumber
     IRONRUBY       = defined?(RUBY_ENGINE) && RUBY_ENGINE == "ironruby"
     WINDOWS        = RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
     OS_X           = RbConfig::CONFIG['host_os'] =~ /darwin/
-    WINDOWS_MODERN = begin
+    WINDOWS_MODERN = WINDOWS && begin
                        ver = /^Microsoft Windows \[Version (\d+)\.(\d+)\.(\d+).*/.match(`ver`)
                        major_ver = ver[1].to_i
                        minor_ver = ver[2].to_i

--- a/lib/cucumber/core/platform.rb
+++ b/lib/cucumber/core/platform.rb
@@ -5,12 +5,23 @@ require 'rbconfig'
 
 module Cucumber
   unless defined?(Cucumber::VERSION)
-    JRUBY         = defined?(JRUBY_VERSION)
-    IRONRUBY      = defined?(RUBY_ENGINE) && RUBY_ENGINE == "ironruby"
-    WINDOWS       = RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
-    OS_X          = RbConfig::CONFIG['host_os'] =~ /darwin/
-    WINDOWS_MRI   = WINDOWS && !JRUBY && !IRONRUBY
-    RUBY_2_0      = RUBY_VERSION =~ /^2\.0/
-    RUBY_1_9      = RUBY_VERSION =~ /^1\.9/
+    JRUBY          = defined?(JRUBY_VERSION)
+    IRONRUBY       = defined?(RUBY_ENGINE) && RUBY_ENGINE == "ironruby"
+    WINDOWS        = RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+    OS_X           = RbConfig::CONFIG['host_os'] =~ /darwin/
+    WINDOWS_MODERN = begin
+                       ver = /^Microsoft Windows \[Version (\d+)\.(\d+)\.(\d+).*/.match(`ver`)
+                       major_ver = ver[1].to_i
+                       minor_ver = ver[2].to_i
+                       build_ver = ver[3].to_i
+                       major_ver > 10 \
+                         || (major_ver == 10 && minor_ver > 0) \
+                         || (major_ver == 10 && build_ver >= 15063)
+                     rescue
+                       false
+                     end
+    WINDOWS_MRI    = WINDOWS && !JRUBY && !IRONRUBY
+    RUBY_2_0       = RUBY_VERSION =~ /^2\.0/
+    RUBY_1_9       = RUBY_VERSION =~ /^1\.9/
   end
 end


### PR DESCRIPTION
Allow Cucumber on Windows 10 to support ANSI coloring into its output without ANSICON

## Summary
Cucumber relies on ANSICON to produce colored output in Windows. Windows 10, however, natively supports it. So I introduce a way for Cucumber to detect more "modern" Windows versions

## Details
As of Windows 10 Microsoft does support ANSI colors in the Command prompt. Even more colors have been added in the Creators Update (256):
https://blogs.msdn.microsoft.com/commandline/2017/04/11/windows-10-creators-update-whats-new-in-bashwsl-windows-console/

I have introduced Cucumber::WINDOWS_MODERN flag, which checks the output of the 'ver' console command. It RegEx matches if the Windows version is equal or higher than Creators Update (10.0.15063).

## Motivation and Context
Cucumber is unnecessary requiring ANSICON for Windows 10, where ANSI colored output is supported. Fix that by outputting colors on Windows versions that support them

## How Has This Been Tested?
I have tested it on Windows 10 Anniversary and Creators Updates

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
