### PR TITLE
Travis: jruby-9.1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2
   - 2.1
   - 2.0.0
-  - jruby-9.1.10.0
+  - jruby-9.1.12.0
 
 matrix:
   allow_failures:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/06/15/jruby-9-1-12-0.html