### PR TITLE
HISTORY.md: Remove a hard space

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -94,7 +94,7 @@
 
   * Calculate actual keyword for snippets (@brasmusson)
 
-### Bugfixes
+### Bugfixes
 
   * Remove keyword from `Test::Case#name` [82](https://github.com/cucumber/cucumber-ruby-core/pull/82) (@richarda)
 


### PR DESCRIPTION
## Summary

The changelog `HISTORY.md` had a badly-rendered heading, and this PR repairs the Markdown rendering.

## Details

I removed a hard space character, and this made the `###` heading function again.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
