### PR TITLE
Travis: Make JRuby produce test coverage info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
+language: ruby
 sudo: false
 
-rvm:
-  - ruby-head
-  - 2.4.1
-  - 2.3.4
-  - 2.2
-  - 2.1
-  - 2.0.0
-  - jruby-9.1.12.0
-
 matrix:
+  include:
+    - rvm: ruby-head
+    - rvm: 2.4.1
+    - rvm: 2.3.4
+    - rvm: 2.2
+    - rvm: 2.1
+    - rvm: 2.0.0
+    - rvm: jruby-9.1.12.0
+      env:
+        - JRUBY_OPTS="--debug"
   allow_failures:
     - rvm: ruby-head
   fast_finish: true


### PR DESCRIPTION
## Summary

This PR enables **test coverage data** in **JRuby** using the environment variable `JRUBY_OPTS=--debug`.

## Details

Travis output snippet **before**:

```
Finished in 8.04 seconds (files took 3.62 seconds to load)
346 examples, 0 failures

Coverage report generated for RSpec to
  /home/travis/build/cucumber/cucumber-ruby-core/coverage.
  0 / 4077 LOC (0.0%) covered.
```

Travis output snippet **after**:

```
Finished in 8.37 seconds (files took 5.94 seconds to load)
346 examples, 0 failures

Coverage report generated for RSpec to
  /home/travis/build/cucumber/cucumber-ruby-core/coverage.
  4048 / 4184 LOC (96.75%) covered.
```

(_Bonus_: We also pass `travis-lint` by adding the `language` key in the YAML configuration.)
