### PR TITLE
Fix misspellings

### DIFF
--- a/lib/cucumber/core/test/result.rb
+++ b/lib/cucumber/core/test/result.rb
@@ -109,7 +109,7 @@ module Cucumber
           end
         end
 
-        # Base class for exceptions that can be raised in a step defintion causing
+        # Base class for exceptions that can be raised in a step definition causing
         # the step to have that result.
         class Raisable < StandardError
           attr_reader :message, :duration

--- a/spec/cucumber/core/ast/doc_string_spec.rb
+++ b/spec/cucumber/core/ast/doc_string_spec.rb
@@ -77,11 +77,11 @@ module Cucumber
             expect( doc_string.encoding ).to eq Encoding.find('US-ASCII')
           end
 
-          it 'allows implicit convertion to a String' do
+          it 'allows implicit conversion to a String' do
             expect( 'expected content' ).to include(doc_string)
           end
 
-          it 'allows explicit convertion to a String' do
+          it 'allows explicit conversion to a String' do
             expect( doc_string.to_s ).to eq 'content'
           end
 

--- a/spec/cucumber/core/ast/location_spec.rb
+++ b/spec/cucumber/core/ast/location_spec.rb
@@ -62,7 +62,7 @@ module Cucumber::Core::Ast
           expect( matching ).to be_match(precise)
         end
 
-        it "does not match a precise location on a differnt line in the same file" do
+        it "does not match a precise location on a different line in the same file" do
           expect( matching ).not_to be_match(same_file_other_line)
         end
 


### PR DESCRIPTION
This PR fixes tiny misspellings.

  - Found using: `find . | misspellings -f -`