### PR TITLE
Add ambiguous result type

### DIFF
--- a/lib/cucumber/core/test/result.rb
+++ b/lib/cucumber/core/test/result.rb
@@ -16,7 +16,7 @@ module Cucumber
               result_type
             end
 
-            [:passed, :failed, :undefined, :unknown, :skipped, :pending].each do |possible_result_type|
+            [:passed, :failed, :undefined, :unknown, :skipped, :pending, :ambiguous].each do |possible_result_type|
               define_method("#{possible_result_type}?") do
                 possible_result_type == to_sym
               end
@@ -174,6 +174,24 @@ module Cucumber
 
           def ok?(be_strict = false)
             true
+          end
+        end
+
+        class Ambiguous < Raisable
+          include Result.query_methods :ambiguous
+
+          def describe_to(visitor, *args)
+            visitor.failed(*args)
+            visitor.duration(duration, *args)
+            self
+          end
+
+          def to_s
+            "F"
+          end
+
+          def ok?(be_strict = false)
+            !be_strict
           end
         end
 


### PR DESCRIPTION
## Summary
Added a new result type for tests that encounter ambiguous steps.

## Details
With this PR and the PR: https://github.com/cucumber/cucumber-ruby/pull/1132 we are trying to fix the issue #1113

## Motivation and Context
cucumber/cucumber-ruby#1113

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
