### PR TITLE
Make the Summary report able to say if the total result is ok.

### DIFF
--- a/lib/cucumber/core/report/summary.rb
+++ b/lib/cucumber/core/report/summary.rb
@@ -11,6 +11,10 @@ module Cucumber
           subscribe_to(event_bus)
         end
 
+        def ok?(be_strict = false)
+          test_cases.ok?(be_strict)
+        end
+
         private
 
         def subscribe_to(event_bus)

--- a/spec/cucumber/core/report/summary_spec.rb
+++ b/spec/cucumber/core/report/summary_spec.rb
@@ -123,5 +123,41 @@ module Cucumber::Core::Report
         end
       end
     end
+
+    context "ok? result" do
+      let(:test_case) { double }
+
+      it "passed test case is ok" do
+        event_bus.send(:test_case_finished, test_case, passed_result)
+
+        expect( @summary.ok? ).to eq true
+      end
+
+      it "skipped test case is ok" do
+        event_bus.send(:test_case_finished, test_case, skipped_result)
+
+        expect( @summary.ok? ).to eq true
+      end
+
+      it "failed test case is not ok" do
+        event_bus.send(:test_case_finished, test_case, failed_result)
+
+        expect( @summary.ok? ).to eq false
+      end
+
+      it "pending test case is ok if not strict" do
+        event_bus.send(:test_case_finished, test_case, pending_result)
+
+        expect( @summary.ok? ).to eq true
+        expect( @summary.ok?(true) ).to eq false
+      end
+
+      it "undefined test case is ok if not strict" do
+        event_bus.send(:test_case_finished, test_case, undefined_result)
+
+        expect( @summary.ok? ).to eq true
+        expect( @summary.ok?(true) ).to eq false
+      end
+    end
   end
 end

--- a/spec/cucumber/core/test/result_spec.rb
+++ b/spec/cucumber/core/test/result_spec.rb
@@ -253,6 +253,7 @@ module Cucumber::Core::Test
       let(:passed)    { Result::Passed.new(Result::Duration.new(11)) }
       let(:skipped)   { Result::Skipped.new }
       let(:unknown)   { Result::Unknown.new }
+      let(:pending)   { Result::Pending.new }
       let(:undefined) { Result::Undefined.new }
       let(:exception) { StandardError.new }
 
@@ -327,6 +328,35 @@ module Cucumber::Core::Test
       it "records exceptions" do
         [passed, failed].each { |r| r.describe_to summary }
         expect( summary.exceptions ).to eq [exception]
+      end
+
+      context "ok? result" do
+        it "passed result is ok" do
+          passed.describe_to summary
+          expect( summary.ok? ).to be true
+        end
+
+        it "skipped result is ok" do
+          skipped.describe_to summary
+          expect( summary.ok? ).to be true
+        end
+
+        it "failed result is not ok" do
+          failed.describe_to summary
+          expect( summary.ok? ).to be false
+        end
+
+        it "pending result is ok if not strict" do
+          pending.describe_to summary
+          expect( summary.ok? ).to be true
+          expect( summary.ok?(true) ).to be false
+        end
+
+        it "undefined result is ok if not strict" do
+          undefined.describe_to summary
+          expect( summary.ok? ).to be true
+          expect( summary.ok?(true) ).to be false
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

Make the Summary report able to say if the total result is ok.

## Details

* Add TYPES constant to Result module
* Make ok? class methods on the Result classes
* Make the Summary result able to way if the total result is ok.

## Motivation and Context

The intention is to remove duplication and simplify the exit code logic in Cucumber-Ruby.

The logic of whether a certain result is ok or not is implemented in each `Result` class - and is used in several formatters. This logic should be used in more places, for instance in the exit code logic in Cucumber-Ruby.

## How Has This Been Tested?

The automated test suite has been updated to verify this behaviour.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
