### PR TITLE
Add a flaky result type to be used for flaky scenarios.

### DIFF
--- a/lib/cucumber/core/test/result.rb
+++ b/lib/cucumber/core/test/result.rb
@@ -5,7 +5,7 @@ module Cucumber
   module Core
     module Test
       module Result
-        TYPES = [:failed, :skipped, :undefined, :pending, :passed, :unknown].freeze
+        TYPES = [:failed, :flaky, :skipped, :undefined, :pending, :passed, :unknown].freeze
 
         def self.ok?(type, be_strict = false)
           private
@@ -121,6 +121,15 @@ module Cucumber
 
           def with_filtered_backtrace(filter)
             self.class.new(duration, filter.new(exception.dup).exception)
+          end
+        end
+
+        # Flaky is not used directly as an execution result, but is used as a
+        # reporting result type for test cases that fails and the passes on
+        # retry, therefore only the class method self.ok? is needed.
+        class Flaky
+          def self.ok?(be_strict = false)
+            !be_strict
           end
         end
 
@@ -268,6 +277,10 @@ module Cucumber
             end
           end
 
+          def decrement_failed
+            @totals[:failed] -= 1
+          end
+          
           private
 
           def get_total(method_name)

--- a/spec/cucumber/core/report/summary_spec.rb
+++ b/spec/cucumber/core/report/summary_spec.rb
@@ -55,6 +55,16 @@ module Cucumber::Core::Report
         expect( @summary.test_cases.total(:undefined) ).to eq(1)
         expect( @summary.test_cases.total ).to eq(1)
       end
+
+      it "handles flaky test cases" do
+        allow(test_case).to receive(:==).and_return(false, true)
+        event_bus.send(:test_case_finished, test_case, failed_result)
+        event_bus.send(:test_case_finished, test_case, passed_result)
+
+        expect( @summary.test_cases.total(:failed) ).to eq(0)
+        expect( @summary.test_cases.total(:flaky) ).to eq(1)
+        expect( @summary.test_cases.total ).to eq(1)
+      end
     end
 
     context "test step summary" do

--- a/spec/cucumber/core/test/result_spec.rb
+++ b/spec/cucumber/core/test/result_spec.rb
@@ -46,6 +46,7 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_undefined }
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).not_to be_skipped   }
+      specify { expect( result ).not_to be_flaky     }
 
       specify { expect( result ).to be_ok }
       specify { expect( result.ok?(false) ).to be_truthy }
@@ -105,6 +106,7 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_undefined }
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).not_to be_skipped   }
+      specify { expect( result ).not_to be_flaky     }
 
       specify { expect( result ).to_not be_ok }
       specify { expect( result.ok?(false) ).to be_falsey }
@@ -130,6 +132,7 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_undefined }
       specify { expect( result ).to     be_unknown   }
       specify { expect( result ).not_to be_skipped   }
+      specify { expect( result ).not_to be_flaky     }
     end
 
     describe Result::Raisable do
@@ -196,6 +199,7 @@ module Cucumber::Core::Test
       specify { expect( result ).to     be_undefined }
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).not_to be_skipped   }
+      specify { expect( result ).not_to be_flaky     }
 
       specify { expect( result ).to be_ok }
       specify { expect( result.ok?(false) ).to be_truthy }
@@ -218,6 +222,7 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_undefined }
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).to     be_skipped   }
+      specify { expect( result ).not_to be_flaky     }
 
       specify { expect( result ).to be_ok }
       specify { expect( result.ok?(false) ).to be_truthy }
@@ -240,11 +245,17 @@ module Cucumber::Core::Test
       specify { expect( result ).not_to be_undefined }
       specify { expect( result ).not_to be_unknown   }
       specify { expect( result ).not_to be_skipped   }
+      specify { expect( result ).not_to be_flaky     }
       specify { expect( result ).to     be_pending   }
 
       specify { expect( result ).to be_ok }
       specify { expect( result.ok?(false) ).to be_truthy }
       specify { expect( result.ok?(true) ).to be_falsey }
+    end
+
+    describe Result::Flaky do
+      specify { expect( Result::Flaky.ok?(false) ).to be_truthy }
+      specify { expect( Result::Flaky.ok?(true) ).to be_falsey }
     end
 
     describe Result::Summary do
@@ -354,6 +365,12 @@ module Cucumber::Core::Test
 
         it "undefined result is ok if not strict" do
           undefined.describe_to summary
+          expect( summary.ok? ).to be true
+          expect( summary.ok?(true) ).to be false
+        end
+
+        it "flaky result is ok if not strict" do
+          summary.flaky
           expect( summary.ok? ).to be true
           expect( summary.ok?(true) ).to be false
         end


### PR DESCRIPTION
## Summary

Add a flaky result type to be used for flaky scenarios.

## Details

Add a flaky result type to be used for flaky scenarios.
* The flaky result type should be ok in non-strict mode and not ok in
  strict mode, so the exit code becomes zero with flaky scenarios in
  non-strict mode.
* Update the Summary report to detect and count flaky scenarios.

Fixes https://github.com/cucumber/cucumber-ruby/issues/1044.

## Motivation and Context

After the `--retry` feature was introduced it makes sense not to report each execution of the scenarios which are retried in the summary, but each retried scenario once - either as `failed` or `flaky` depending on if they passes after retry or not.

## How Has This Been Tested?

The automated test suite is updated to verify this new behaviour.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
