### PR TITLE
Fix DataTable's Location to be aware of all of its lines

### DIFF
--- a/lib/cucumber/core/gherkin/ast_builder.rb
+++ b/lib/cucumber/core/gherkin/ast_builder.rb
@@ -373,6 +373,12 @@ module Cucumber
           def rows
             attributes[:rows] = attributes[:rows].map { |r| r[:cells].map { |c| c[:value] } }
           end
+
+          def location
+            first_line = attributes[:location][:line]
+            last_line = first_line + attributes[:rows].length - 1
+            Ast::Location.new(file, first_line..last_line)
+          end
         end
 
         class DocStringBuilder < Builder

--- a/spec/cucumber/core/test/filters/locations_filter_spec.rb
+++ b/spec/cucumber/core/test/filters/locations_filter_spec.rb
@@ -96,6 +96,8 @@ module Cucumber::Core
                 Given a table
                   | a | b |
                   | 1 | 2 |
+                  | 3 | 4 |
+
           END
         end
 
@@ -192,9 +194,24 @@ module Cucumber::Core
             test_cases.find { |c| c.name == 'with a table' }
           end
 
-          it "matches a location on the first table row" do
+          it "matches a location at the start of the table" do
             location = Ast::Location.new(file, 23)
             expect( test_case.match_locations?([location]) ).to be_truthy
+          end
+
+          it "matches a location in the middle of the table" do
+            location = Ast::Location.new(file, 24)
+            expect( test_case.match_locations?([location]) ).to be_truthy
+          end
+
+          it "matches a location at the end of the table" do
+            location = Ast::Location.new(file, 25)
+            expect( test_case.match_locations?([location]) ).to be_truthy
+          end
+
+          it "does not match a location after the table" do
+            location = Ast::Location.new(file, 26)
+            expect( test_case.match_locations?([location]) ).to be_falsey
           end
         end
 


### PR DESCRIPTION
Hi folks! I'm back with another DataTable-related bugfix. When being built, DataTables would build their `Ast::Location` with only the first line. In the following example feature, this led to commands like `cucumber features/test.feature:5` working, but `cucumber features/test.feature:6` not running any tests, because no `Test::Case` reported containing that line.

```cucumber
Scenario: Run scenario with a data table
  Given a file named "features/test.feature" with:
    """
    Feature: 

      Scenario: DataTable
        Given this step is a table step
          | a | b |
          | c | d |
    """
  When I run `cucumber features/test.feature:6 --format pretty --quiet`
  Then it should pass with exactly:
    """
    Feature: 

      Scenario: DataTable
        Given this step is a table step
          | a | b |
          | c | d |

    1 scenario (1 passed)
    1 step (1 passed)
      
    """
```

## How Has This Been Tested?

I'm not quite sure how best to test this. My first inclination is to add a unit test, but there appear to be no unit tests in this project for `Cucumber::Core::Gherkin::AstBuilder` or any of its internals. The cucumber acceptance test above could be added to the parent `cucumber/cucumber-ruby` project, but it seems a bit too edge-casey for a full acceptance test, IMO. Thoughts?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
