### PR TITLE
Handle selective strict settings.

### DIFF
--- a/lib/cucumber/core/report/summary.rb
+++ b/lib/cucumber/core/report/summary.rb
@@ -12,7 +12,7 @@ module Cucumber
           subscribe_to(event_bus)
         end
 
-        def ok?(be_strict = false)
+        def ok?(be_strict = Test::Result::StrictConfiguration.new)
           test_cases.ok?(be_strict)
         end
 

--- a/spec/cucumber/core/report/summary_spec.rb
+++ b/spec/cucumber/core/report/summary_spec.rb
@@ -159,14 +159,16 @@ module Cucumber::Core::Report
         event_bus.send(:test_case_finished, test_case, pending_result)
 
         expect( @summary.ok? ).to eq true
-        expect( @summary.ok?(true) ).to eq false
+        be_strict = ::Cucumber::Core::Test::Result::StrictConfiguration.new([:pending])
+        expect( @summary.ok?(be_strict) ).to eq false
       end
 
       it "undefined test case is ok if not strict" do
         event_bus.send(:test_case_finished, test_case, undefined_result)
 
         expect( @summary.ok? ).to eq true
-        expect( @summary.ok?(true) ).to eq false
+        be_strict = ::Cucumber::Core::Test::Result::StrictConfiguration.new([:undefined])
+        expect( @summary.ok?(be_strict) ).to eq false
       end
     end
   end


### PR DESCRIPTION
## Summary

Let the result types affected the the strict settings be controlled individually, so only a subset of the can be set to be handled strict.

## Details

Make it possible for each of the strict affected result types (`undefined`, `pending`, and `flaky`) to be controlled individually.

## Motivation and Context

Needed by cucumber/cucumber-ruby#1169.

## How Has This Been Tested?

The automated test suite has been updated to verify this behaviour.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
