### PR TITLE
Do not create test cases for scenarios with no steps.

### DIFF
--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -45,7 +45,7 @@ module Cucumber
         end
 
         def on_test_case(source)
-          Test::Case.new(test_steps, source).describe_to(receiver)
+          Test::Case.new(test_steps, source).describe_to(receiver) if test_steps.count > 0
           @test_steps = nil
           self
         end

--- a/spec/cucumber/core/compiler_spec.rb
+++ b/spec/cucumber/core/compiler_spec.rb
@@ -157,6 +157,23 @@ module Cucumber::Core
       end
     end
 
+    context 'empty scenarios' do
+      it 'does not create test cases for them' do
+        gherkin_documents = [
+          gherkin do
+            feature do
+              scenario do
+              end
+            end
+          end
+        ]
+        compile(gherkin_documents) do |visitor|
+          expect( visitor ).to receive(:test_case).never
+          expect( visitor ).to receive(:done).once.ordered
+        end
+      end
+    end
+
     describe Compiler::FeatureCompiler do
       let(:receiver) { double('receiver') }
       let(:compiler) { Compiler::FeatureCompiler.new(receiver) }

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -277,7 +277,7 @@ module Cucumber
             gherkin = Gherkin::Document.new('features/treasure.feature', %{# language: en-pirate
               Ahoy matey!: Treasure map
                 Heave to: Find the treasure
-                  Gangway!: a map
+                  Gangway! a map
             })
             receiver = double.as_null_object
             expect( receiver ).to receive(:test_case) do |test_case|

--- a/spec/cucumber/core/test/filters/locations_filter_spec.rb
+++ b/spec/cucumber/core/test/filters/locations_filter_spec.rb
@@ -96,8 +96,6 @@ module Cucumber::Core
                 Given a table
                   | a | b |
                   | 1 | 2 |
-
-              Scenario: empty
           END
         end
 
@@ -110,13 +108,6 @@ module Cucumber::Core
           filter = Test::LocationsFilter.new([location])
           compile [doc], receiver, [filter]
           expect(receiver.test_case_locations).to eq [test_case_named('two').location]
-        end
-
-        it 'matches the precise location of an empty scenario' do
-          location = test_case_named('empty').location
-          filter = Test::LocationsFilter.new([location])
-          compile [doc], receiver, [filter]
-          expect(receiver.test_case_locations).to eq [test_case_named('empty').location]
         end
 
         it 'matches multiple locations' do


### PR DESCRIPTION
## Summary

Do not create test cases for scenarios with no steps.

## Details

To be consistent with the (Pickle) compiler in the Gherkin library, test cases should not be created for scenarios with no steps.

## Motivation and Context

Fixing the root cause of cucumber/cucumber#243.

## How Has This Been Tested?

The automated test suite has been updated to verify this behaviour.

I have manually verified that `cucumber --dry-run` with empty scenarios does not raise the exception of  cucumber/cucumber#243 with this change.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
