### PR TITLE
Travis: use jruby-9.1.13.0; add env LANG env vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,12 @@ matrix:
     - rvm: 2.2
     - rvm: 2.1
     - rvm: 2.0.0
-    - rvm: jruby-9.1.12.0
+    - rvm: jruby-9.1.13.0
       env:
         - JRUBY_OPTS="--debug"
+        - LC_ALL=en_US.UTF-8
+        - LANG=en_US.UTF-8
+        - LANGUAGE=en_US.UTF-8        
   allow_failures:
     - rvm: ruby-head
   fast_finish: true


### PR DESCRIPTION
This PR updates JRuby to latest released - `jruby-9.1.13.0`.

The ENV var changes come from the Travis config og the [cucumber-ruby](https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml) project. 
