### PR TITLE
Add query if handlers exist for event id to the event bus.

### DIFF
--- a/lib/cucumber/core/event_bus.rb
+++ b/lib/cucumber/core/event_bus.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'cucumber/core/events'
 
 module Cucumber
@@ -33,6 +34,12 @@ module Cucumber
         raise ArgumentError, "Event type #{event.class} is not registered. Try one of these:\n#{event_types.values.join("\n")}" unless is_registered_type?(event.class)
         handlers_for(event.class).each { |handler| handler.call(event) }
         @event_queue << event
+      end
+
+      # Query whether at least one handler exist for an event id
+      def handlers_exist_for?(event_id)
+        event_class = event_types.fetch(event_id)
+        !handlers_for(event_class).empty?
       end
 
       def method_missing(event_id, *args)

--- a/spec/cucumber/core/event_bus_spec.rb
+++ b/spec/cucumber/core/event_bus_spec.rb
@@ -158,6 +158,25 @@ module Cucumber
         expect { event_bus.event_types[:foo] = :bar }.to raise_error(RuntimeError)
       end
 
+      context "querying if handlers exist for event id" do
+        context "no handler exist" do
+          it "query returns false" do
+            expect(event_bus.handlers_exist_for?(:test_event)).to be false
+          end
+        end
+
+        context "a handler exist" do
+          before(:each) do
+            event_bus.on(:test_event) do |event|
+            end
+          end
+
+          it "query returns true" do
+            expect(event_bus.handlers_exist_for?(:test_event)).to be true
+          end
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
## Summary

Add query if handlers exist for event id to the event bus.

## Details

Add query if handlers exist for event id to the event bus.

## Motivation and Context

This is needed to be able to only fire the `test_case_count` event if a listener has been registered in cucumber/cucumber-ruby#1170 (see https://github.com/cucumber/cucumber-ruby/pull/1170#issuecomment-323219831).

## How Has This Been Tested?

Automated test suite has been updated to verify this behavior. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
