### PR TITLE
Travis: use jruby-9.1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - rvm: 2.3.4
     - rvm: 2.2
     - rvm: 2.1
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.15.0
       env:
         - JRUBY_OPTS="--debug"
         - LC_ALL=en_US.UTF-8


### PR DESCRIPTION

## Summary

This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/12/07/jruby-9-1-15-0.html

