### PR TITLE
Add #original_location to Cucumber::Core::Ast::Step and Cucumber::Core::Test::Step

### DIFF
--- a/lib/cucumber/core/ast/step.rb
+++ b/lib/cucumber/core/ast/step.rb
@@ -35,10 +35,15 @@ module Cucumber
           end
         end
 
+        def original_location
+          location
+        end
+
         def inspect
           keyword_and_text = [keyword, text].join(": ")
           %{#<#{self.class} "#{keyword_and_text}" (#{location})>}
         end
+
 
         private
 
@@ -59,6 +64,10 @@ module Cucumber
 
         def all_locations
           @outline_step.all_locations
+        end
+
+        def original_location
+          @outline_step.location
         end
 
         alias :step_backtrace_line :backtrace_line

--- a/lib/cucumber/core/test/step.rb
+++ b/lib/cucumber/core/test/step.rb
@@ -48,6 +48,10 @@ module Cucumber
           source.last.location
         end
 
+        def original_location
+          source.last.original_location
+        end
+
         def action_location
           @action.location
         end

--- a/spec/cucumber/core/ast/step_spec.rb
+++ b/spec/cucumber/core/ast/step_spec.rb
@@ -22,6 +22,12 @@ module Cucumber
           end
         end
 
+        describe "original_location" do
+          it("return the location of the step") do
+            expect(step.original_location).to be(step.location)
+          end
+        end
+
         describe "describing itself" do
           let(:visitor) { double }
 
@@ -123,6 +129,13 @@ module Cucumber
           ExpandedOutlineStep.new(outline_step, language, location, comments, keyword, text, multiline_arg)
         end
 
+        describe "original_location" do
+          it("return the location of the outline step") do
+            allow(outline_step).to receive(:location).and_return(double)
+            expect(step.original_location).to be(outline_step.location)
+          end
+        end
+
         describe "describing itself" do
           let(:visitor) { double }
 
@@ -171,4 +184,3 @@ module Cucumber
     end
   end
 end
-

--- a/spec/cucumber/core/test/step_spec.rb
+++ b/spec/cucumber/core/test/step_spec.rb
@@ -73,12 +73,13 @@ module Cucumber::Core::Test
       end
     end
 
-    it "exposes the text and location of the AST step or hook as attributes" do
-      text, location = double, double
-      step_or_hook = double(text: text, location: location)
+    it "exposes the text, location and original location of the AST step or hook as attributes" do
+      text, location, original_location = double, double, double
+      step_or_hook = double(text: text, location: location, original_location: original_location)
       test_step = Step.new([step_or_hook])
-      expect( test_step.text     ).to eq text
-      expect( test_step.location ).to eq location
+      expect( test_step.text              ).to eq text
+      expect( test_step.location          ).to eq location
+      expect( test_step.original_location ).to eq original_location
     end
 
     it "exposes the location of the action as attribute" do


### PR DESCRIPTION
## Summary

Add Cucumber::Core::Ast::Step#original_location.

## Details

The intention is to make the location of the OutlineStep easily accessible from the source of a Cucumber::Core::Test::Step.

## Motivation and Context

A Test Step from a Scenario Outline has two locations, the location of the Outline Step and the location of the Example Table Row. This is made explicit by the Gherkin compiler in that a Pickle Step has a locations attribute, that in case of that the Pickle Step was compiled from a Scenario Outline contains both the location of the Outline Step and the Example Table Row. The Cucumber-Ruby compiler does not take this into account, the `Ast::Step`, `Ast::ExpandedOutlineStep` and `Test::Step` all (through include of the `HasLocation` module) all respond to the `#location` method to provide one and only one location. In case of `Ast::ExpandedOutlineStep` and `Test::Step` the location provided is the location of the Example Table Row. 

Since `Ast::ExpandedOutlineStep` and `Test::Step` has two equally important locations (neither cannot be deduced from the other), they should in principle not provide a `#location` method. However since the use of the `HasLocation` module and the `#location` method is ubiquitous and depended on in many placed. This PR instead introduce a `#original_location` on `Ast::Step` and `Ast::ExpandedOutlineStep` so that both the locations of a Test Step from a Scenario Outline can be easily accessible from the source (`#source.last`) of the Test Step, without first having to determine whether the Test Step comes from a Scenario or a Scenario Outline.

Fixes #149.

## How Has This Been Tested?

The automated test suite has been extended to verify this behavior.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
