### PR TITLE
Add the GherkinSourceParsedEvent

### DIFF
--- a/lib/cucumber/core.rb
+++ b/lib/cucumber/core.rb
@@ -15,17 +15,17 @@ module Cucumber
       self
     end
 
-    def compile(gherkin_documents, last_receiver, filters = [])
+    def compile(gherkin_documents, last_receiver, filters = [], event_bus = EventBus.new)
       first_receiver = compose(filters, last_receiver)
       compiler = Compiler.new(first_receiver)
-      parse gherkin_documents, compiler
+      parse gherkin_documents, compiler, event_bus
       self
     end
 
     private
 
-    def parse(gherkin_documents, compiler)
-      parser = Core::Gherkin::Parser.new(compiler)
+    def parse(gherkin_documents, compiler, event_bus)
+      parser = Core::Gherkin::Parser.new(compiler, event_bus)
       gherkin_documents.each do |document|
         parser.document document
       end

--- a/lib/cucumber/core/events.rb
+++ b/lib/cucumber/core/events.rb
@@ -1,8 +1,19 @@
+# coding: utf-8
 require 'cucumber/core/event'
 
 module Cucumber
   module Core
     module Events
+
+      # Signals that a gherkin source has been parsed
+      class GherkinSourceParsed < Event.new(:uri, :gherkin_document)
+        # The uri of the file
+        attr_reader :uri
+
+        # @return [GherkinDocument] the GherkinDocument Ast Node
+        attr_reader :gherkin_document
+
+      end
 
       # Signals that a {Test::Case} is about to be executed
       class TestCaseStarted < Event.new(:test_case)
@@ -43,10 +54,11 @@ module Cucumber
 
       end
 
-      # The registry contains all the events registered in the core, 
+      # The registry contains all the events registered in the core,
       # that will be used by the {EventBus} by default.
       def self.registry
         build_registry(
+          GherkinSourceParsed,
           TestCaseStarted,
           TestStepStarted,
           TestStepFinished,

--- a/lib/cucumber/core/gherkin/parser.rb
+++ b/lib/cucumber/core/gherkin/parser.rb
@@ -11,11 +11,12 @@ module Cucumber
       ParseError = Class.new(StandardError)
 
       class Parser
-        attr_reader :receiver
-        private     :receiver
+        attr_reader :receiver, :event_bus
+        private     :receiver, :event_bus
 
-        def initialize(receiver)
+        def initialize(receiver, event_bus)
           @receiver = receiver
+          @event_bus = event_bus
         end
 
         def document(document)
@@ -26,6 +27,7 @@ module Cucumber
 
           begin
             result = parser.parse(scanner, token_matcher)
+            event_bus.gherkin_source_parsed(document.uri, result.dup)
 
             receiver.feature core_builder.feature(result)
           rescue *PARSER_ERRORS => e


### PR DESCRIPTION
## Summary

Add the `GherkinSourceParsedEvent`

## Details

Let the parser issued a `GherkinSourceParsedEvent` with the Gherkin Document after parsing a feature file.

## Motivation and Context

The `GherkinSourceParsedEvent` is useful for the formatters when the LegacyApi is removed from Cucumber-Ruby (https://github.com/cucumber/cucumber-ruby/pull/1230)

## How Has This Been Tested?

The automated test suite has been extended to verify this functionality.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
