### PR TITLE
Let Scenarios with no Steps get the result status Undefined

### DIFF
--- a/lib/cucumber/core/test/runner.rb
+++ b/lib/cucumber/core/test/runner.rb
@@ -17,7 +17,9 @@ module Cucumber
           @running_test_step = nil
           event_bus.test_case_started(test_case)
           descend.call(self)
-          event_bus.test_case_finished(test_case, running_test_case.result)
+          result = running_test_case.result
+          result = Result::Undefined.new('The test case has no steps', Result::UnknownDuration.new, ["#{test_case.location}:in `#{test_case.name}'"]) if result.unknown?
+          event_bus.test_case_finished(test_case, result)
           self
         end
 

--- a/spec/cucumber/core/test/runner_spec.rb
+++ b/spec/cucumber/core/test/runner_spec.rb
@@ -78,7 +78,7 @@ module Cucumber::Core::Test
         it "emits the test_case_finished event after running the the test case" do
           expect(event_bus).to receive(:test_case_finished) do |reported_test_case, result|
             expect( reported_test_case ).to eq test_case
-            expect( result ).to be_unknown
+            expect( result ).to be_undefined
           end
           test_case.describe_to runner
         end


### PR DESCRIPTION
## Summary

Let Scenarios with no Steps get the result status Undefined.

## Details

After #156 Scenarios with no Steps are compiled into Pickles with no Steps, therefore this change should be made.

Is built on top of #156.

## Motivation and Context

See https://github.com/cucumber/cucumber/issues/249#issue-251216268

## How Has This Been Tested?

The automated test suite has been updated to verify this behavior.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
