### PR TITLE
Travis: use JRuby 9.2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - rvm: 2.4
     - rvm: 2.3
     - rvm: 2.2
-    - rvm: jruby-9.2.0.0
+    - rvm: jruby-9.2.5.0
       env:
         - JRUBY_OPTS="--debug"
         - LC_ALL=en_US.UTF-8


### PR DESCRIPTION
## Summary

This harmonizes with https://github.com/cucumber/cucumber-ruby/pull/1335 

## Details

The latest generally-available JRuby is 9.2.5.0, and this PR updates the version used to that.

## Why this does not build green on JRuby

https://github.com/cucumber/cucumber-ruby/issues/1336