### PR TITLE
Travis: Allow Failure on jruby until bug fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,12 @@ matrix:
     - rvm: 2.3
     - rvm: 2.2
     - rvm: jruby-9.2.5.0
-      env:
-        - JRUBY_OPTS="--debug"
-        - LC_ALL=en_US.UTF-8
-        - LANG=en_US.UTF-8
-        - LANGUAGE=en_US.UTF-8
+      env: JRUBY_OPTS="--debug" LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8
   allow_failures:
     - rvm: ruby-head
+    # https://github.com/cucumber/cucumber-ruby/issues/1336
+    - rvm: jruby-9.2.5.0
+
   fast_finish: true
 
 # whitelist


### PR DESCRIPTION
## Summary

There's a bug in Google Protobuf gem, which makes it not install in JRuby.

This PR allows CI failures in JRuby to happen, and see JRuby as not-so-supported right now, until that bug is fixed.

## Details

- add jruby-9.2.5.0 to allowed-to-fail CI matrix jobs list
- make `travis lint` pass, by lining up all the env vars for the JRuby job
- https://github.com/cucumber/cucumber-ruby/issues/1336 is the Issue which we're waiting for

## Motivation and Context

I want us to have a trustable green build.

## How Has This Been Tested?

CI runs only.

## Types of changes

A CI change.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

