### PR TITLE
CI: Use latest JRuby 9.2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ matrix:
     - rvm: 2.4
     - rvm: 2.3
     - rvm: 2.2
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0
       env: JRUBY_OPTS="--debug" LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8
   allow_failures:
     - rvm: ruby-head
     # https://github.com/cucumber/cucumber-ruby/issues/1336
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0
 
   fast_finish: true
 


### PR DESCRIPTION
## Summary

Use latest JRuby.

## Details

This PR updates the CI matrix to use latest JRuby, 9.2.6.0.

[JRuby 9.2.6.0 release blog post](https://www.jruby.org/2019/02/11/jruby-9-2-6-0.html)


## Motivation and Context

Be up to date!

## How Has This Been Tested?

CI runs only.

## Types of changes

A CI matrix change.

