### PR TITLE
Avoid YARD docstring warning UnknownParam

### DIFF
--- a/lib/cucumber/core/event_bus.rb
+++ b/lib/cucumber/core/event_bus.rb
@@ -11,7 +11,7 @@ module Cucumber
     class EventBus
       attr_reader :event_types
 
-      # @param [Hash{Symbol => Class}] a hash of event types to use on the bus
+      # @param registry [Hash{Symbol => Class}] a hash of event types to use on the bus
       def initialize(registry = Events.registry)
         @event_types = registry.freeze
         @handlers = {}


### PR DESCRIPTION
## Summary

Make YARD recognize the `registry` parameter, avoiding a warning and improving the API docs.

## Details

Warning output:

```
lib/cucumber/core/event_bus.rb:14: [UnknownParam] @param tag has unknown parameter name: a
```

## Motivation and Context

This avoids warning output, and fixes YARD docs.

## How Has This Been Tested?

I have _not_ tested it.

## Types of changes

A docs change.

