### PR TITLE
CI: Use jruby-9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 
 matrix:
   include:
@@ -8,12 +7,12 @@ matrix:
     - rvm: 2.5
     - rvm: 2.4
     - rvm: 2.3
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
       env: JRUBY_OPTS="--debug" LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8
   allow_failures:
     - rvm: ruby-head
     # https://github.com/cucumber/cucumber-ruby/issues/1336
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
 
   fast_finish: true
 


### PR DESCRIPTION
## Summary

 Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

We are still failing on the known issues.

