### PR TITLE
Store in Result the embeddings returned by a step

### DIFF
--- a/lib/cucumber/core/test/invoke_result.rb
+++ b/lib/cucumber/core/test/invoke_result.rb
@@ -1,0 +1,23 @@
+module Cucumber
+  module Core
+    module Test
+      class InvokeResult
+        attr_reader :embeddings
+        def initialize(embeddings = [])
+          @embeddings = embeddings
+        end
+      end
+
+      class PassedInvokeResult < InvokeResult
+      end
+
+      class FailedInvokeResult < InvokeResult
+        attr_reader :exception
+        def initialize(exception, embeddings = [])
+          super(embeddings)
+          @exception = exception
+        end
+      end
+    end
+  end
+end

--- a/lib/cucumber/core/test/result.rb
+++ b/lib/cucumber/core/test/result.rb
@@ -54,14 +54,16 @@ module Cucumber
         class Passed
           include Result.query_methods :passed
           attr_accessor :duration
+          attr_reader :embeddings
 
           def self.ok?(be_strict = false)
             true
           end
 
-          def initialize(duration)
+          def initialize(duration, embeddings = [])
             raise ArgumentError unless duration
             @duration = duration
+            @embeddings = embeddings
           end
 
           def describe_to(visitor, *args)
@@ -98,16 +100,18 @@ module Cucumber
           include Result.query_methods :failed
 
           attr_reader :duration, :exception
+          attr_reader :embeddings
 
           def self.ok?(be_strict = false)
             false
           end
 
-          def initialize(duration, exception)
+          def initialize(duration, exception, embeddings = [])
             raise ArgumentError unless duration
             raise ArgumentError unless exception
             @duration = duration
             @exception = exception
+            @embeddings = embeddings
           end
 
           def describe_to(visitor, *args)
@@ -140,7 +144,7 @@ module Cucumber
           end
 
           def with_duration(new_duration)
-            self.class.new(new_duration, exception)
+            self.class.new(new_duration, exception, embeddings)
           end
 
           def with_appended_backtrace(step)
@@ -149,7 +153,7 @@ module Cucumber
           end
 
           def with_filtered_backtrace(filter)
-            self.class.new(duration, filter.new(exception.dup).exception)
+            self.class.new(duration, filter.new(exception.dup).exception, embeddings)
           end
         end
 

--- a/lib/cucumber/core/test/result.rb
+++ b/lib/cucumber/core/test/result.rb
@@ -69,6 +69,7 @@ module Cucumber
           def describe_to(visitor, *args)
             visitor.passed(*args)
             visitor.duration(duration, *args)
+            @embeddings.each { |e| visitor.embed(e['src'], e['mime_type'], e['label']) }
             self
           end
 
@@ -118,6 +119,7 @@ module Cucumber
             visitor.failed(*args)
             visitor.duration(duration, *args)
             visitor.exception(exception, *args) if exception
+            @embeddings.each { |e| visitor.embed(e['src'], e['mime_type'], e['label']) }
             self
           end
 
@@ -368,6 +370,10 @@ module Cucumber
 
           def duration(duration)
             @durations << duration
+            self
+          end
+
+          def embed(*)
             self
           end
 

--- a/lib/cucumber/core/test/runner.rb
+++ b/lib/cucumber/core/test/runner.rb
@@ -90,6 +90,10 @@ module Cucumber
             self
           end
 
+          def embed(*)
+            self
+          end
+
           attr_reader :status
           private :status
 

--- a/spec/cucumber/core/test/result_spec.rb
+++ b/spec/cucumber/core/test/result_spec.rb
@@ -10,8 +10,11 @@ module Cucumber::Core::Test
     let(:args)    { double('args')    }
 
     describe Result::Passed do
-      subject(:result) { Result::Passed.new(duration) }
+      subject(:result) { Result::Passed.new(duration, embeddings) }
       let(:duration)   { Result::Duration.new(1 * 1000 * 1000) }
+      let(:embedding1) { {'src' => 'src1', 'mime_type' => 'mime_type1', 'label' => 'label1'} }
+      let(:embedding2) { {'src' => 'src2', 'mime_type' => 'mime_type2', 'label' => 'label2'} }
+      let(:embeddings) { [embedding1, embedding2] }
 
       it "describes itself to a visitor" do
         expect( visitor ).to receive(:passed).with(args)
@@ -32,7 +35,11 @@ module Cucumber::Core::Test
         expect( result.duration ).to eq duration
       end
 
-      it "requires the constructor argument" do
+      it "has embeddings" do
+        expect( result.embeddings ).to eq embeddings
+      end
+
+      it "requires the first constructor argument" do
         expect { Result::Passed.new }.to raise_error(ArgumentError)
       end
 
@@ -58,9 +65,12 @@ module Cucumber::Core::Test
     end
 
     describe Result::Failed do
-      subject(:result) { Result::Failed.new(duration, exception) }
+      subject(:result) { Result::Failed.new(duration, exception, embeddings) }
       let(:duration)   { Result::Duration.new(1 * 1000 * 1000) }
       let(:exception)  { StandardError.new("error message") }
+      let(:embedding1) { {'src' => 'src1', 'mime_type' => 'mime_type1', 'label' => 'label1'} }
+      let(:embedding2) { {'src' => 'src2', 'mime_type' => 'mime_type2', 'label' => 'label2'} }
+      let(:embeddings) { [embedding1, embedding2] }
 
       it "describes itself to a visitor" do
         expect( visitor ).to receive(:failed).with(args)
@@ -76,6 +86,10 @@ module Cucumber::Core::Test
       it "converts to a Cucumber::Message::TestResult" do
         message = result.to_message
         expect(message.status).to eq(Cucumber::Messages::TestStepResult::Status::FAILED)
+      end
+
+      it "has embeddings" do
+        expect( result.embeddings ).to eq embeddings
       end
 
       it "requires both constructor arguments" do

--- a/spec/cucumber/core/test/result_spec.rb
+++ b/spec/cucumber/core/test/result_spec.rb
@@ -19,6 +19,8 @@ module Cucumber::Core::Test
       it "describes itself to a visitor" do
         expect( visitor ).to receive(:passed).with(args)
         expect( visitor ).to receive(:duration).with(duration, args)
+        expect( visitor ).to receive(:embed).with(embedding1['src'], embedding1['mime_type'], embedding1['label']).ordered
+        expect( visitor ).to receive(:embed).with(embedding2['src'], embedding2['mime_type'], embedding2['label']).ordered
         result.describe_to(visitor, args)
       end
 
@@ -76,6 +78,8 @@ module Cucumber::Core::Test
         expect( visitor ).to receive(:failed).with(args)
         expect( visitor ).to receive(:duration).with(duration, args)
         expect( visitor ).to receive(:exception).with(exception, args)
+        expect( visitor ).to receive(:embed).with(embedding1['src'], embedding1['mime_type'], embedding1['label']).ordered
+        expect( visitor ).to receive(:embed).with(embedding2['src'], embedding2['mime_type'], embedding2['label']).ordered
         result.describe_to(visitor, args)
       end
 


### PR DESCRIPTION
## Summary

<!--- Provide a general summary description of your changes -->

In order to allow embeddings to be transferred from a wire response to a step `Result`, the invocation of a step needs to be capable of returning a data structure. This patch use that data structure (if any, previous design is still allowed) to build the `Result` object.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I'm looking into cucumber-cpp for my company.
We need to be able to embed text or images into the reports, but that feature is not available when using the wire protocol.

This patch is the 2nd of a series of 4, respectively impacting _cucumber-ruby_, _cucumber-ruby-core_, _cucumber-ruby-wire_ and _cucumber-cpp_.

Basically, the idea is to allow embeddings to be specified in the success or fail responses sent through the wire protocol. E.g.:
```
["success",{"embeddings":[{"label":"Embedded text","mime_type":"text/plain","src":"Some text"}]}]
["fail",{"embeddings":[{"label":"Embedded image","mime_type":"image/png;base64","src":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="}],"message":"There was no  banana"}]
```

The embeddings will then be stored in the step Result in order to be accessible by the formatter.

The patch on _cucumber-ruby_ (cucumber/cucumber-ruby#1354) will let formatters access embeddings stored in a step result.
The patch on _cucumber-ruby-core_ (cucumber/cucumber-ruby-core#170) will store in the step result the embeddings returned by the step invocation.
The patch on _cucumber-ruby-wire_ (cucumber/cucumber-ruby-wire#20) will allow the embeddings stored in the wire response to be returned by the wire-based step invocation process.
The patch on _cucumber-cpp_ (cucumber/cucumber-cpp#223) will allow C++ steps to send embeddings through wire responses.

Note: embeddings were not considered to be useful for pending steps, but support should be possible if required.

## Details

<!--- Describe your changes in detail -->

In the current implementation, it's not possible to access data from the wire response as nothing is returned from the wire invocation when a step succeed (a step is considered successful by default, an exception needs to be raised in case of failing or pending step).

**Successful step**
```
Cucumber::Core::Test::Runner::RunningTestCase::Status::Base.execute
  Cucumber::Core::Test::Step.execute
    Cucumber::Core::Test::Action.execute
      block -> Cucumber::StepMatch.invoke
        Cucumber::Wire::StepDefinition.invoke
          Cucumber::Wire::Protocol.invoke
            Cucumber::Wire::Protocol::Requests::Invoke.execute
              Cucumber::Wire::RequestHandler.execute
                Cucumber::Wire::Connection.call_remote
                  Cucumber::Wire::DataPacket reponse = // parsed packet
                  Cucumber::Wire::DataPacket.handle_with
                    Cucumber::Wire::DataPacket.handle_success // noop
                  // response discarded
      Cucumber::Core::Test::Action.passed -> return Cucumber::Core::Test::Result::Passed
  Cucumber::Core::Test::Result::Passed.describe_to(Cucumber::Core::Test::Runner::RunningTestCase)
    Cucumber::Core::Test::Runner::RunningTestCase.passed
      Cucumber::Core::Test::Runner::RunningTestCase@status = Cucumber::Core::Test::Runner::RunningTestCase::Status::Passing
```

**Failing step**
```
Cucumber::Core::Test::Runner::RunningTestCase::Status::Base.execute
  Cucumber::Core::Test::Step.execute
    Cucumber::Core::Test::Action.execute
      block -> Cucumber::StepMatch.invoke
        Cucumber::Wire::StepDefinition.invoke
          Cucumber::Wire::Protocol.invoke
            Cucumber::Wire::Protocol::Requests::Invoke.execute
              Cucumber::Wire::RequestHandler.execute
                Cucumber::Wire::Connection.call_remote
                  Cucumber::Wire::DataPacket reponse = // parsed packet
                  Cucumber::Wire::DataPacket.handle_with
                    Cucumber::Wire::RequestHandler.handle_fail -> throw Cucumber::Wire::Exception // error message (from response) embedded in exception
                  // response discarded
      Rescue in Cucumber::Core::Test::Action.execute
        Cucumber::Core::Test::Action.failed -> return Cucumber::Core::Test::Result::Failed
  Cucumber::Core::Test::Result::Failed.describe_to(Cucumber::Core::Test::Runner::RunningTestCase)
    Cucumber::Core::Test::Runner::RunningTestCase.failed
      Cucumber::Core::Test::Runner::RunningTestCase@status = Cucumber::Core::Test::Runner::RunningTestCase::Status::Failing
```

This patch does three things:
- It adds an `embeddings` field to the `Passed` and `Failed` responses and make their `describe_to` methods notify visitors from the availability of embeddings.
- It creates two new classes, `PassedInvokeResult` and `FailedInvokeResult`, to be returned by what is effectively invoking the step.
- Add code to allow an `Action` to check if the invocation of a step returned one of those objects, and create a `Passed` or `Failed` result accordingly.

Those changes should be backward compatible: successful step invocations that return nothing, failing step invocations that throw an exception and other behaviors are still supported.

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Add the embeddings field to the unit tests verifying the visitor mechanism of Result.
Add unit tests to verify that Action.execute returns a Passed/Failed object when the invocation of a step returns an PassedInvokeResult/FailedInvokeResult object (previous tests already verify that current behaviors still continue to work).


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (code change that does not change external functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
