### PR TITLE
Enable circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
       - checkout
       - restore_cache:
           keys:
-          - bundle-{{ checksum "cucumber.gemspec" }}
+          - bundle-{{ checksum "cucumber-core.gemspec" }}
       - run:
           name: install dependencies
           command: |
@@ -16,7 +16,7 @@ commands:
       - save_cache:
           paths:
             - ./vendor/bundle
-          key: bundle-{{ checksum "cucumber.gemspec" }}
+          key: bundle-{{ checksum "cucumber-core.gemspec" }}
 
   test:
     description: "Run tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 commands:
-  build_and_test:
+  build:
     description: "Build and run the tests"
 
     steps:
@@ -11,10 +11,23 @@ commands:
           command: |
             bundle install --jobs=4 --retry=3 --path vendor/bundle
 
+  test:
+    description: "Run tests"
+    steps:
       - run:
           name: run tests
           command: |
             bundle exec rspec
+
+  test_allow_failure:
+    description: "Run tests (allow failure so workflow is not marked as failed)"
+    steps:
+      - run:
+          name: run tests with allowed failure
+          command: |
+            set -o errexit
+            bundle exec rspec
+            set -o errexit
 
   export_jruby_env:
     description: "Export needed ENV for JRuby"
@@ -35,7 +48,8 @@ jobs:
 
     working_directory: ~/repo
     steps:
-      - build_and_test
+      - build
+      - test
 
   build-ruby-2_4:
     docker:
@@ -43,7 +57,8 @@ jobs:
 
     working_directory: ~/repo
     steps:
-      - build_and_test
+      - build
+      - test
 
   build-ruby-2_5:
     docker:
@@ -51,7 +66,8 @@ jobs:
 
     working_directory: ~/repo
     steps:
-      - build_and_test
+      - build
+      - test
 
   build-ruby-2_6:
     docker:
@@ -59,7 +75,8 @@ jobs:
 
     working_directory: ~/repo
     steps:
-      - build_and_test
+      - build
+      - test
 
   build-jruby:
     docker:
@@ -68,7 +85,8 @@ jobs:
     working_directory: ~/repo
     steps:
       - export_jruby_env
-      - build_and_test
+      - build
+      - test_allow_failure
 
   build-ruby-latest:
     docker:
@@ -76,7 +94,8 @@ jobs:
 
     working_directory: ~/repo
     steps:
-      - build_and_test
+      - build
+      - test_allow_failure
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,93 @@
+version: 2.1
+
+commands:
+  build_and_test:
+    description: "Build and run the tests"
+
+    steps:
+      - checkout
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - run:
+          name: run tests
+          command: |
+            bundle exec rspec
+
+  export_jruby_env:
+    description: "Export needed ENV for JRuby"
+
+    steps:
+      - run:
+          name: "Export JRurby ENV"
+          command: |
+            export JRUBY_OPTS="--debug"
+            export LC_ALL=en_US.UTF-8
+            export LANG=en_US.UTF-8
+            export LANGUAGE=en_US.UTF-8
+
+jobs:
+  build-ruby-2_3:
+    docker:
+      - image: circleci/ruby:2.3.8
+
+    working_directory: ~/repo
+    steps:
+      - build_and_test
+
+  build-ruby-2_4:
+    docker:
+      - image: circleci/ruby:2.4.5
+
+    working_directory: ~/repo
+    steps:
+      - build_and_test
+
+  build-ruby-2_5:
+    docker:
+      - image: circleci/ruby:2.5.5
+
+    working_directory: ~/repo
+    steps:
+      - build_and_test
+
+  build-ruby-2_6:
+    docker:
+      - image: circleci/ruby:2.6.4
+
+    working_directory: ~/repo
+    steps:
+      - build_and_test
+
+  build-jruby:
+    docker:
+      - image: circleci/jruby:9.2.8.0
+
+    working_directory: ~/repo
+    steps:
+      - export_jruby_env
+      - build_and_test
+
+  build-ruby-latest:
+    docker:
+      - image: circleci/ruby:latest
+
+    working_directory: ~/repo
+    steps:
+      - build_and_test
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build-ruby-2_3
+      - build-ruby-2_4
+      - build-ruby-2_5
+      - build-ruby-2_6
+      - build-ruby-latest
+      - build-jruby
+
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,17 @@ commands:
 
     steps:
       - checkout
+      - restore_cache:
+          keys:
+          - bundle-{{ checksum "cucumber.gemspec" }}
       - run:
           name: install dependencies
           command: |
             bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: bundle-{{ checksum "cucumber.gemspec" }}
 
   test:
     description: "Run tests"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cucumber-core
 
 [![Chat with us](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/cucumber/cucumber-ruby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![CircleCI](https://circleci.com/gh/cucumber/cucumber-ruby-core.svg?style=svg)](https://circleci.com/gh/cucumber/cucumber-ruby-core)
 [![Build Status](https://travis-ci.org/cucumber/cucumber-ruby-core.svg?branch=master)](https://travis-ci.org/cucumber/cucumber-ruby-core)
 [![Code Climate](https://codeclimate.com/github/cucumber/cucumber-ruby-core.svg)](https://codeclimate.com/github/cucumber/cucumber-ruby-core)
 [![Coverage Status](https://coveralls.io/repos/cucumber/cucumber-ruby-core/badge.svg?branch=master)](https://coveralls.io/r/cucumber/cucumber-ruby-core?branch=master)


### PR DESCRIPTION
## Summary

The mono-repo already runs on CircleCI. It'll be more convenient to have a single place to look at when it comes to CI issues.

Note: an admin of the repo will have to enable CircleCI to test if it works ;)

## Details

The proposed config should run as Travis does (there is not yet an "allow failure" option in CircleCI that said)

## Types of changes

Does not apply.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
