### PR TITLE
Enable possibility to reference Gherkin and cucumber-messages gems from git

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,16 @@
 source "https://rubygems.org"
 
-gem 'gherkin', path: ENV['GHERKIN_RUBY'] if ENV['GHERKIN_RUBY']
+if ENV['GHERKIN_RUBY_REPO']
+   gem 'gherkin', git: ENV['GHERKIN_RUBY_REPO']
+ elsif ENV['GHERKIN_RUBY']
+   gem 'gherkin', path: ENV['GHERKIN_RUBY']
+ end
 
-gem 'cucumber-messages', path: ENV['CUCUMBER_MESSAGES_RUBY'] if ENV['CUCUMBER_MESSAGES_RUBY']
+ if ENV['CUCUMBER_MESSAGES_RUBY_REPO']
+   gem 'cucumber-messages', git: ENV['CUCUMBER_MESSAGES_RUBY_REPO']
+ elsif ENV['CUCUMBER_MESSAGES_RUBY']
+   gem 'cucumber-messages', path: ENV['CUCUMBER_MESSAGES_RUBY']
+ end
 
 # Use an older protobuf on JRuby and MRI < 2.5
 gem 'google-protobuf', '~> 3.2.0.2' if RbConfig::CONFIG['MAJOR'].to_i == 2 && RbConfig::CONFIG['MINOR'].to_i < 5 || RUBY_PLATFORM == 'java'


### PR DESCRIPTION
## Summary

Currently, we can reference gems `Gherkin`and `cucumber-messages` from the filesystem when developing.
That said, when using the CI, we can not reference the Git repos.

## Details

Add those ENV variables:
```
export GHERKIN_RUBY_REPO="https://github.com/cucumber/gherkin-ruby"
export CUCUMBER_MESSAGES_RUBY_REPO="https://github.com/cucumber/cucumber-messages-ruby.git"
```

## Motivation and Context

Ease preparing releases of gems from `master` branch on the mono repo copies.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.