### PR TITLE
CircleCI: run rake instead of rspec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
       - run:
           name: run tests
           command: |
-            bundle exec rspec
+            bundle exec rake
 
   test_allow_failure:
     description: "Run tests (allow failure so workflow is not marked as failed)"
@@ -33,7 +33,7 @@ commands:
           name: run tests with allowed failure
           command: |
             set -o errexit
-            bundle exec rspec
+            bundle exec rake
             set -o errexit
 
   export_jruby_env:
@@ -106,6 +106,22 @@ jobs:
 
 workflows:
   version: 2
+
+  nightly-build:
+    triggers:
+      - schedule:
+          cron: "0 5 * * *"
+          filters:
+            branches:
+              only:
+                - master
+
+    jobs:
+      - build-ruby-2_3
+      - build-ruby-2_4
+      - build-ruby-2_5
+      - build-ruby-2_6
+
   build:
     jobs:
       - build-ruby-2_3

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .ruby-version
 /doc
 .bundle
+vendor/

--- a/spec/capture_warnings.rb
+++ b/spec/capture_warnings.rb
@@ -6,7 +6,7 @@ module CaptureWarnings
   def report_warnings(&block)
     current_dir = Dir.pwd
     warnings, errors = capture_error(&block).partition { |line| line.include?('warning') }
-    project_warnings, other_warnings = warnings.uniq.partition { |line| line.include?(current_dir) }
+    project_warnings, other_warnings = warnings.uniq.partition { |line| line.include?(current_dir) && !line.include?('/vendor/') }
 
     if errors.any?
       puts errors.join("\n")


### PR DESCRIPTION
## Summary

Current build only runs `bundle exec rspec` excluding some of the tests.
Running `bundle exec rake` is a better option.
 
And also a nightly build as been added like on `cucumber-ruby`

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
