### PR TITLE
Add protobuf-formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
 
-## [In Git](https://github.com/cucumber/cucumber-ruby-core/compare/v5.0.1...master)
+## [5.0.2](https://github.com/cucumber/cucumber-ruby-core/compare/v5.0.1...v5.0.2)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
 
+## [In Git](https://github.com/cucumber/cucumber-ruby-core/compare/v5.0.2...master)
+
+### Changed
+
+* N/A
+
+### Added
+
+* N/A
+
+### Fixed
+
+* N/A
+
+### Removed
+
+* N/A
+
+### Improved
+
+* N/A
+
+
 ## [5.0.2](https://github.com/cucumber/cucumber-ruby-core/compare/v5.0.1...v5.0.2)
 
 ### Changed

--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
                     'source_code_uri' => 'https://github.com/cucumber/cucumber-ruby-core',
                   }
 
-  s.add_dependency 'gherkin', '~> 8.1', '>= 8.1.1'
-  s.add_dependency 'cucumber-messages', '~> 7.0'
+  s.add_dependency 'gherkin', '~> 9.0', '>= 9.0.0'
+  s.add_dependency 'cucumber-messages', '~> 8.0'
   s.add_dependency 'cucumber-tag_expressions', '~> 2.0', '>= 2.0.2'
   s.add_dependency 'backports', '~> 3.15', '>= 3.15.0'
 

--- a/lib/cucumber/core.rb
+++ b/lib/cucumber/core.rb
@@ -11,13 +11,13 @@ module Cucumber
     def execute(gherkin_documents, filters = [], event_bus = EventBus.new)
       yield event_bus if block_given?
       receiver = Test::Runner.new(event_bus)
-      compile gherkin_documents, receiver, filters, event_bus
+      compile gherkin_documents, receiver, filters, event_bus, Cucumber::Messages::IdGenerator::Incrementing.new
       self
     end
 
-    def compile(gherkin_documents, last_receiver, filters, event_bus)
+    def compile(gherkin_documents, last_receiver, filters, event_bus, id_generator)
       first_receiver = compose(filters, last_receiver)
-      compiler = Compiler.new(first_receiver)
+      compiler = Compiler.new(first_receiver, id_generator)
       parse gherkin_documents, compiler, event_bus
       self
     end

--- a/lib/cucumber/core.rb
+++ b/lib/cucumber/core.rb
@@ -18,14 +18,14 @@ module Cucumber
     def compile(gherkin_documents, last_receiver, filters, event_bus, id_generator)
       first_receiver = compose(filters, last_receiver)
       compiler = Compiler.new(first_receiver, id_generator)
-      parse gherkin_documents, compiler, event_bus
+      parse gherkin_documents, compiler, event_bus, id_generator
       self
     end
 
     private
 
-    def parse(gherkin_documents, compiler, event_bus)
-      parser = Core::Gherkin::Parser.new(compiler, event_bus)
+    def parse(gherkin_documents, compiler, event_bus, id_generator)
+      parser = Core::Gherkin::Parser.new(compiler, event_bus, { id_generator: id_generator })
       gherkin_documents.each do |document|
         parser.document document
       end

--- a/lib/cucumber/core.rb
+++ b/lib/cucumber/core.rb
@@ -11,11 +11,11 @@ module Cucumber
     def execute(gherkin_documents, filters = [], event_bus = EventBus.new)
       yield event_bus if block_given?
       receiver = Test::Runner.new(event_bus)
-      compile gherkin_documents, receiver, filters
+      compile gherkin_documents, receiver, filters, event_bus
       self
     end
 
-    def compile(gherkin_documents, last_receiver, filters = [], event_bus = EventBus.new)
+    def compile(gherkin_documents, last_receiver, filters, event_bus)
       first_receiver = compose(filters, last_receiver)
       compiler = Compiler.new(first_receiver)
       parse gherkin_documents, compiler, event_bus

--- a/lib/cucumber/core.rb
+++ b/lib/cucumber/core.rb
@@ -8,7 +8,7 @@ require 'cucumber/core/test/runner'
 module Cucumber
   module Core
 
-    def execute(gherkin_documents, filters = [], event_bus = EventBus.new)
+    def execute(gherkin_documents, filters, event_bus)
       yield event_bus if block_given?
       receiver = Test::Runner.new(event_bus)
       compile gherkin_documents, receiver, filters, event_bus, Cucumber::Messages::IdGenerator::Incrementing.new

--- a/lib/cucumber/core.rb
+++ b/lib/cucumber/core.rb
@@ -8,10 +8,10 @@ require 'cucumber/core/test/runner'
 module Cucumber
   module Core
 
-    def execute(gherkin_documents, filters, event_bus)
+    def execute(gherkin_documents, filters, event_bus, id_generator)
       yield event_bus if block_given?
       receiver = Test::Runner.new(event_bus)
-      compile gherkin_documents, receiver, filters, event_bus, Cucumber::Messages::IdGenerator::Incrementing.new
+      compile gherkin_documents, receiver, filters, event_bus, id_generator
       self
     end
 

--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -79,7 +79,7 @@ module Cucumber
             doc_string = pickle_step.argument.doc_string
             Test::DocString.new(
               doc_string.content,
-              doc_string.contentType,
+              doc_string.content_type,
               Test::Location.new(uri, line)
             )
           elsif pickle_step.argument.data_table

--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -45,7 +45,13 @@ module Cucumber
           )
         end
 
-        Test::Case.new(pickle.name, test_steps, Test::Location.new(uri, lines), tags, pickle.language)
+        Test::Case.new(
+          pickle.name,
+          test_steps,
+          Test::Location.new(uri, lines),
+          tags,
+          pickle.language,
+          [])
       end
 
       def create_test_step(pickle_step, uri, location_query)

--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -14,9 +14,9 @@ module Cucumber
       attr_reader :receiver
       private     :receiver
 
-      def initialize(receiver)
+      def initialize(receiver, id_generator)
         @receiver = receiver
-        @id_generator = Cucumber::Messages::IdGenerator::Incrementing.new
+        @id_generator = id_generator
       end
 
       def pickle(pickle, location_query)

--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -32,11 +32,11 @@ module Cucumber
 
       def create_test_case(pickle, location_query)
         uri = pickle.uri
-        test_steps = pickle.steps.map { |step| create_test_step(step, uri, location_query) }
-
         lines = location_query.pickle_locations(pickle).map do |location|
           location.line
         end.sort.reverse
+
+        test_steps = pickle.steps.map { |step| create_test_step(step, uri, location_query) }
 
         tags = pickle.tags.map do |tag|
           Test::Tag.new(

--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -46,6 +46,7 @@ module Cucumber
         end
 
         Test::Case.new(
+          pickle.id,
           pickle.name,
           test_steps,
           Test::Location.new(uri, lines),

--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -16,6 +16,7 @@ module Cucumber
 
       def initialize(receiver)
         @receiver = receiver
+        @id_generator = Cucumber::Messages::IdGenerator::Incrementing.new
       end
 
       def pickle(pickle, location_query)
@@ -46,6 +47,7 @@ module Cucumber
         end
 
         Test::Case.new(
+          @id_generator.new_id,
           pickle.id,
           pickle.name,
           test_steps,
@@ -62,6 +64,7 @@ module Cucumber
 
         multiline_arg = create_multiline_arg(pickle_step, uri, location_query)
         Test::Step.new(
+          @id_generator.new_id,
           pickle_step.id,
           pickle_step.text,
           Test::Location.new(uri, lines),
@@ -79,7 +82,7 @@ module Cucumber
             doc_string = pickle_step.argument.doc_string
             Test::DocString.new(
               doc_string.content,
-              doc_string.content_type,
+              doc_string.media_type,
               Test::Location.new(uri, line)
             )
           elsif pickle_step.argument.data_table

--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -61,7 +61,7 @@ module Cucumber
         end.sort.reverse
 
         multiline_arg = create_multiline_arg(pickle_step, uri, location_query)
-        Test::Step.new(pickle_step.text, Test::Location.new(uri, lines), multiline_arg)
+        Test::Step.new(pickle_step.text, Test::Location.new(uri, lines), multiline_arg, nil)
       end
 
       def create_multiline_arg(pickle_step, uri, location_query)

--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -61,7 +61,13 @@ module Cucumber
         end.sort.reverse
 
         multiline_arg = create_multiline_arg(pickle_step, uri, location_query)
-        Test::Step.new(pickle_step.text, Test::Location.new(uri, lines), multiline_arg, nil)
+        Test::Step.new(
+          pickle_step.id,
+          pickle_step.text,
+          Test::Location.new(uri, lines),
+          multiline_arg,
+          nil
+        )
       end
 
       def create_multiline_arg(pickle_step, uri, location_query)

--- a/lib/cucumber/core/event_bus.rb
+++ b/lib/cucumber/core/event_bus.rb
@@ -18,7 +18,7 @@ module Cucumber
         @event_queue = []
       end
 
-      # Register for an event. The handler proc will be called back with each of the attributes
+      # Register for an event. The handler proc will be called back with each of the attributes
       # of the event.
       def on(event_id, handler_object = nil, &handler_proc)
         handler = handler_proc || handler_object
@@ -28,7 +28,7 @@ module Cucumber
         broadcast_queued_events_to handler, event_class
       end
 
-      # Broadcast an event
+      # Broadcast an event
       def broadcast(event)
         raise ArgumentError, "Event type #{event.class} is not registered. Try one of these:\n#{event_types.values.join("\n")}" unless is_registered_type?(event.class)
         handlers_for(event.class).each { |handler| handler.call(event) }

--- a/lib/cucumber/core/events.rb
+++ b/lib/cucumber/core/events.rb
@@ -5,20 +5,16 @@ module Cucumber
   module Core
     module Events
 
+      # Signals an envelope from Cucumber::Messages
+      class Envelope < Event.new(:gherkin_document)
+        attr_reader :envelope
+      end
+
       # Signals that a gherkin source has been parsed
       class GherkinSourceParsed < Event.new(:gherkin_document)
         # @return [GherkinDocument] the GherkinDocument Ast Node
         attr_reader :gherkin_document
 
-      end
-
-      # Signals a Pickle has been computed from a Gherkin document
-      class Pickle < Core::Event.new(:pickle, :test_case)
-        # @return Cucumber::Messages::Pickle, the parsed pickle.
-        attr_reader :pickle
-
-        # The {Test::Case} associated to the Pickle
-        attr_reader :test_case
       end
 
       # Signals that a {Test::Case} is about to be executed
@@ -64,8 +60,8 @@ module Cucumber
       # that will be used by the {EventBus} by default.
       def self.registry
         build_registry(
+          Envelope,
           GherkinSourceParsed,
-          Pickle,
           TestCaseStarted,
           TestStepStarted,
           TestStepFinished,

--- a/lib/cucumber/core/events.rb
+++ b/lib/cucumber/core/events.rb
@@ -12,6 +12,15 @@ module Cucumber
 
       end
 
+      # Signals a Pickle has been computed from a Gherkin document
+      class Pickle < Core::Event.new(:pickle, :test_case)
+        # @return Cucumber::Messages::Pickle, the parsed pickle.
+        attr_reader :pickle
+
+        # The {Test::Case} associated to the Pickle
+        attr_reader :test_case
+      end
+
       # Signals that a {Test::Case} is about to be executed
       class TestCaseStarted < Event.new(:test_case)
 
@@ -20,7 +29,7 @@ module Cucumber
 
       end
 
-      # Signals that a {Test::Step} is about to be executed
+      # Signals that a {Test::Step} is about to be executed
       class TestStepStarted < Event.new(:test_step)
 
         # @return [Test::Step] the test step to be executed
@@ -56,6 +65,7 @@ module Cucumber
       def self.registry
         build_registry(
           GherkinSourceParsed,
+          Pickle,
           TestCaseStarted,
           TestStepStarted,
           TestStepFinished,

--- a/lib/cucumber/core/gherkin/location_query.rb
+++ b/lib/cucumber/core/gherkin/location_query.rb
@@ -7,8 +7,8 @@ module Cucumber
     module Gherkin
       class LocationQuery
         def process(message)
-          if message.gherkinDocument
-            process_gherkin_document(message.gherkinDocument)
+          if message.gherkin_document
+            process_gherkin_document(message.gherkin_document)
           elsif message.pickle
             process_pickle(message.pickle)
           end
@@ -20,20 +20,20 @@ module Cucumber
 
         def pickle_locations(pickle)
           [
-            scenario_by_id[pickle.sourceIds[0]],
-            pickle.sourceIds.length > 1 ? table_row_by_id[pickle.sourceIds[1]] : nil
+            scenario_by_id[pickle.ast_node_ids[0]],
+            pickle.ast_node_ids.length > 1 ? table_row_by_id[pickle.ast_node_ids[1]] : nil
           ].compact.map(&:location)
         end
 
         def pickle_step_locations(pickle_step)
           [
-            gherkin_steps_by_id[pickle_step.sourceIds[0]],
-            pickle_step.sourceIds.length > 1 ? table_row_by_id[pickle_step.sourceIds[1]] : nil
+            gherkin_steps_by_id[pickle_step.ast_node_ids[0]],
+            pickle_step.ast_node_ids.length > 1 ? table_row_by_id[pickle_step.ast_node_ids[1]] : nil
           ].compact.map(&:location)
         end
 
         def pickle_step_argument_location(pickle_step)
-          scenario_step = gherkin_steps_by_id[pickle_step.sourceIds[0]]
+          scenario_step = gherkin_steps_by_id[pickle_step.ast_node_ids[0]]
           if scenario_step
             case scenario_step.argument
             when :doc_string
@@ -45,7 +45,7 @@ module Cucumber
         end
 
         def pickle_tag_location(pickle_tag)
-          tag_by_id[pickle_tag.sourceId].location
+          tag_by_id[pickle_tag.ast_node_id].location
         end
 
         private

--- a/lib/cucumber/core/gherkin/parser.rb
+++ b/lib/cucumber/core/gherkin/parser.rb
@@ -29,7 +29,7 @@ module Cucumber
               event_bus.envelope(message)
             elsif !message.attachment.nil?
               # Parse error
-              raise Core::Gherkin::ParseError.new("#{document.uri}: #{message.attachment.data}")
+              raise Core::Gherkin::ParseError.new("#{document.uri}: #{message.attachment.text}")
             else
               raise "Unknown message: #{message.to_hash}"
             end

--- a/lib/cucumber/core/gherkin/parser.rb
+++ b/lib/cucumber/core/gherkin/parser.rb
@@ -21,7 +21,8 @@ module Cucumber
             if !message.gherkinDocument.nil?
               event_bus.gherkin_source_parsed(message.gherkinDocument)
             elsif !message.pickle.nil?
-              receiver.pickle(message.pickle)
+              test_case = receiver.pickle(message.pickle)
+              event_bus.pickle(message.pickle, test_case)
             elsif !message.attachment.nil?
               # Parse error
               raise Core::Gherkin::ParseError.new("#{document.uri}: #{message.attachment.data}")

--- a/lib/cucumber/core/gherkin/parser.rb
+++ b/lib/cucumber/core/gherkin/parser.rb
@@ -11,10 +11,11 @@ module Cucumber
         attr_reader :receiver, :event_bus
         private     :receiver, :event_bus
 
-        def initialize(receiver, event_bus)
+        def initialize(receiver, event_bus, gherkin_options)
           @receiver = receiver
           @event_bus = event_bus
           @location_query = LocationQuery.new
+          @gherkin_options = gherkin_options
         end
 
         def document(document)
@@ -42,7 +43,7 @@ module Cucumber
             include_source: false,
             include_gherkin_document: true,
             include_pickles: true
-          }
+          }.merge(@gherkin_options)
         end
 
         def done

--- a/lib/cucumber/core/gherkin/parser.rb
+++ b/lib/cucumber/core/gherkin/parser.rb
@@ -23,9 +23,10 @@ module Cucumber
             @location_query.process(message)
             if !message.gherkinDocument.nil?
               event_bus.gherkin_source_parsed(message.gherkinDocument)
+              event_bus.envelope(message)
             elsif !message.pickle.nil?
-              test_case =  receiver.pickle(message.pickle, @location_query)
-              event_bus.pickle(message.pickle, test_case)
+              receiver.pickle(message.pickle, @location_query)
+              event_bus.envelope(message)
             elsif !message.attachment.nil?
               # Parse error
               raise Core::Gherkin::ParseError.new("#{document.uri}: #{message.attachment.data}")

--- a/lib/cucumber/core/gherkin/parser.rb
+++ b/lib/cucumber/core/gherkin/parser.rb
@@ -21,8 +21,8 @@ module Cucumber
           messages = ::Gherkin.from_source(document.uri, document.body, gherkin_options(document))
           messages.each do |message|
             @location_query.process(message)
-            if !message.gherkinDocument.nil?
-              event_bus.gherkin_source_parsed(message.gherkinDocument)
+            if !message.gherkin_document.nil?
+              event_bus.gherkin_source_parsed(message.gherkin_document)
               event_bus.envelope(message)
             elsif !message.pickle.nil?
               receiver.pickle(message.pickle, @location_query)

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+require 'securerandom'
 require 'cucumber/core/test/result'
 require 'cucumber/tag_expressions'
 
@@ -7,10 +7,11 @@ module Cucumber
   module Core
     module Test
       class Case
-        attr_reader :name, :test_steps, :location, :tags, :language, :around_hooks
+        attr_reader :id, :name, :test_steps, :location, :tags, :language, :around_hooks
 
         def initialize(name, test_steps, location, tags, language, around_hooks = [])
           raise ArgumentError.new("test_steps should be an Array but is a #{test_steps.class}") unless test_steps.is_a?(Array)
+          @id = SecureRandom.uuid
           @name = name
           @test_steps = test_steps
           @location = location

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -25,7 +25,8 @@ module Cucumber
           Cucumber::Messages::Envelope.new(
             testCase: Cucumber::Messages::TestCase.new(
               id: @id,
-              pickleId: @pickle_id
+              pickleId: @pickle_id,
+              testSteps: @test_steps.map(&:to_message)
             )
           )
         end

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'securerandom'
 require 'cucumber/core/test/result'
 require 'cucumber/tag_expressions'
 
@@ -9,9 +8,9 @@ module Cucumber
       class Case
         attr_reader :id, :name, :test_steps, :location, :tags, :language, :around_hooks
 
-        def initialize(pickle_id ,name, test_steps, location, tags, language, around_hooks)
+        def initialize(id, pickle_id ,name, test_steps, location, tags, language, around_hooks)
           raise ArgumentError.new("test_steps should be an Array but is a #{test_steps.class}") unless test_steps.is_a?(Array)
-          @id = SecureRandom.uuid
+          @id = id
           @pickle_id = pickle_id
           @name = name
           @test_steps = test_steps
@@ -47,11 +46,11 @@ module Cucumber
         end
 
         def with_steps(test_steps)
-          self.class.new(@pickle_id, name, test_steps, location, tags, language, around_hooks)
+          self.class.new(@id, @pickle_id, name, test_steps, location, tags, language, around_hooks)
         end
 
         def with_around_hooks(around_hooks)
-          self.class.new(@pickle_id, name, test_steps, location, tags, language, around_hooks)
+          self.class.new(@id, @pickle_id, name, test_steps, location, tags, language, around_hooks)
         end
 
         def match_tags?(*expressions)

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -9,9 +9,10 @@ module Cucumber
       class Case
         attr_reader :id, :name, :test_steps, :location, :tags, :language, :around_hooks
 
-        def initialize(name, test_steps, location, tags, language, around_hooks)
+        def initialize(pickle_id ,name, test_steps, location, tags, language, around_hooks)
           raise ArgumentError.new("test_steps should be an Array but is a #{test_steps.class}") unless test_steps.is_a?(Array)
           @id = SecureRandom.uuid
+          @pickle_id = pickle_id
           @name = name
           @test_steps = test_steps
           @location = location
@@ -45,11 +46,11 @@ module Cucumber
         end
 
         def with_steps(test_steps)
-          self.class.new(name, test_steps, location, tags, language, around_hooks)
+          self.class.new(@pickle_id, name, test_steps, location, tags, language, around_hooks)
         end
 
         def with_around_hooks(around_hooks)
-          self.class.new(name, test_steps, location, tags, language, around_hooks)
+          self.class.new(@pickle_id, name, test_steps, location, tags, language, around_hooks)
         end
 
         def match_tags?(*expressions)

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -23,10 +23,10 @@ module Cucumber
 
         def to_envelope
           Cucumber::Messages::Envelope.new(
-            testCase: Cucumber::Messages::TestCase.new(
+            test_case: Cucumber::Messages::TestCase.new(
               id: @id,
-              pickleId: @pickle_id,
-              testSteps: @test_steps.map(&:to_message)
+              pickle_id: @pickle_id,
+              test_steps: @test_steps.map(&:to_message)
             )
           )
         end

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -9,7 +9,7 @@ module Cucumber
       class Case
         attr_reader :id, :name, :test_steps, :location, :tags, :language, :around_hooks
 
-        def initialize(name, test_steps, location, tags, language, around_hooks = [])
+        def initialize(name, test_steps, location, tags, language, around_hooks)
           raise ArgumentError.new("test_steps should be an Array but is a #{test_steps.class}") unless test_steps.is_a?(Array)
           @id = SecureRandom.uuid
           @name = name
@@ -18,6 +18,15 @@ module Cucumber
           @tags = tags
           @language = language
           @around_hooks = around_hooks
+        end
+
+        def to_envelope
+          Cucumber::Messages::Envelope.new(
+            testCase: Cucumber::Messages::TestCase.new(
+              id: @id,
+              pickleId: @pickle_id
+            )
+          )
         end
 
         def step_count

--- a/lib/cucumber/core/test/location.rb
+++ b/lib/cucumber/core/test/location.rb
@@ -93,6 +93,7 @@ module Cucumber
 
           def initialize(raw_data)
             super Array(raw_data).to_set
+            raise StandardError, "Raw data can't be empty" if data.empty?
           end
 
           def first

--- a/lib/cucumber/core/test/step.rb
+++ b/lib/cucumber/core/test/step.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'securerandom'
 
+require 'cucumber/messages'
 require 'cucumber/core/test/result'
 require 'cucumber/core/test/action'
 require 'cucumber/core/test/empty_multiline_argument'
@@ -11,10 +12,10 @@ module Cucumber
       class Step
         attr_reader :id, :text, :location, :multiline_arg
 
-        def initialize(pickle_step_id, text, location, multiline_arg, action)
+        def initialize(id, pickle_step_id, text, location, multiline_arg, action)
           raise ArgumentError if text.nil? || text.empty?
+          @id = id
           @pickle_step_id = pickle_step_id
-          @id = SecureRandom.uuid
           @text = text
           @location = location
           @multiline_arg = multiline_arg || Test::EmptyMultilineArgument.new
@@ -45,7 +46,14 @@ module Cucumber
         end
 
         def with_action(action_location = nil, &block)
-          self.class.new(@pickle_step_id, text, location, multiline_arg, Test::Action.new(action_location, &block))
+          self.class.new(
+            @id,
+            @pickle_step_id,
+            text,
+            location,
+            multiline_arg,
+            Test::Action.new(action_location, &block)
+          )
         end
 
         def backtrace_line
@@ -66,8 +74,8 @@ module Cucumber
       end
 
       class HookStep < Step
-        def initialize(hook_id, text, location, action)
-          super(nil, text, location, Test::EmptyMultilineArgument.new, action)
+        def initialize(id, hook_id, text, location, action)
+          super(id, nil, text, location, Test::EmptyMultilineArgument.new, action)
           @hook_id = hook_id
         end
 

--- a/lib/cucumber/core/test/step.rb
+++ b/lib/cucumber/core/test/step.rb
@@ -32,7 +32,7 @@ module Cucumber
         def to_message
           Cucumber::Messages::TestCase::TestStep.new(
             id: @id,
-            pickleStepId: @pickle_step_id
+            pickle_step_id: @pickle_step_id
           )
         end
 

--- a/lib/cucumber/core/test/step.rb
+++ b/lib/cucumber/core/test/step.rb
@@ -11,13 +11,14 @@ module Cucumber
       class Step
         attr_reader :id, :text, :location, :multiline_arg
 
-        def initialize(text, location, multiline_arg = Test::EmptyMultilineArgument.new, action = Test::UndefinedAction.new(location))
+        def initialize(text, location, multiline_arg, action)
           raise ArgumentError if text.nil? || text.empty?
+
           @id = SecureRandom.uuid
           @text = text
           @location = location
-          @multiline_arg = multiline_arg
-          @action = action
+          @multiline_arg = multiline_arg || Test::EmptyMultilineArgument.new
+          @action = action || Test::UndefinedAction.new(location)
         end
 
         def describe_to(visitor, *args)
@@ -26,6 +27,12 @@ module Cucumber
 
         def hook?
           false
+        end
+
+        def to_message
+          Cucumber::Messages::TestCase::TestStep.new(
+            id: @id
+          )
         end
 
         def skip(*args)

--- a/lib/cucumber/core/test/step.rb
+++ b/lib/cucumber/core/test/step.rb
@@ -66,12 +66,20 @@ module Cucumber
       end
 
       class HookStep < Step
-        def initialize(text, location, action)
+        def initialize(hook_id, text, location, action)
           super(nil, text, location, Test::EmptyMultilineArgument.new, action)
+          @hook_id = hook_id
         end
 
         def hook?
           true
+        end
+
+        def to_message
+          Cucumber::Messages::TestCase::TestStep.new(
+            id: @id,
+            hookId: @hook_id
+          )
         end
       end
     end

--- a/lib/cucumber/core/test/step.rb
+++ b/lib/cucumber/core/test/step.rb
@@ -11,9 +11,9 @@ module Cucumber
       class Step
         attr_reader :id, :text, :location, :multiline_arg
 
-        def initialize(text, location, multiline_arg, action)
+        def initialize(pickle_step_id, text, location, multiline_arg, action)
           raise ArgumentError if text.nil? || text.empty?
-
+          @pickle_step_id = pickle_step_id
           @id = SecureRandom.uuid
           @text = text
           @location = location
@@ -31,7 +31,8 @@ module Cucumber
 
         def to_message
           Cucumber::Messages::TestCase::TestStep.new(
-            id: @id
+            id: @id,
+            pickleStepId: @pickle_step_id
           )
         end
 
@@ -44,7 +45,7 @@ module Cucumber
         end
 
         def with_action(action_location = nil, &block)
-          self.class.new(text, location, multiline_arg, Test::Action.new(action_location, &block))
+          self.class.new(@pickle_step_id, text, location, multiline_arg, Test::Action.new(action_location, &block))
         end
 
         def backtrace_line
@@ -66,7 +67,7 @@ module Cucumber
 
       class HookStep < Step
         def initialize(text, location, action)
-          super(text, location, Test::EmptyMultilineArgument.new, action)
+          super(nil, text, location, Test::EmptyMultilineArgument.new, action)
         end
 
         def hook?

--- a/lib/cucumber/core/test/step.rb
+++ b/lib/cucumber/core/test/step.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'securerandom'
 
 require 'cucumber/core/test/result'
 require 'cucumber/core/test/action'
@@ -8,10 +9,11 @@ module Cucumber
   module Core
     module Test
       class Step
-        attr_reader :text, :location, :multiline_arg
+        attr_reader :id, :text, :location, :multiline_arg
 
         def initialize(text, location, multiline_arg = Test::EmptyMultilineArgument.new, action = Test::UndefinedAction.new(location))
           raise ArgumentError if text.nil? || text.empty?
+          @id = SecureRandom.uuid
           @text = text
           @location = location
           @multiline_arg = multiline_arg

--- a/lib/cucumber/core/test/step.rb
+++ b/lib/cucumber/core/test/step.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'securerandom'
 
 require 'cucumber/messages'
 require 'cucumber/core/test/result'

--- a/lib/cucumber/core/version.rb
+++ b/lib/cucumber/core/version.rb
@@ -3,7 +3,7 @@ module Cucumber
   module Core
     class Version
       def self.to_s
-        "5.0.1"
+        "5.0.2"
       end
     end
   end

--- a/spec/cucumber/core/compiler_spec.rb
+++ b/spec/cucumber/core/compiler_spec.rb
@@ -171,7 +171,7 @@ module Cucumber::Core
       allow( visitor ).to receive(:test_suite).and_yield(visitor)
       allow( visitor ).to receive(:test_case).and_yield(visitor)
       yield visitor
-      super(gherkin_documents, visitor)
+      super(gherkin_documents, visitor, [], EventBus.new)
     end
 
   end

--- a/spec/cucumber/core/compiler_spec.rb
+++ b/spec/cucumber/core/compiler_spec.rb
@@ -8,6 +8,8 @@ module Cucumber::Core
     include Gherkin::Writer
     include Cucumber::Core
 
+    let(:id_generator) { Cucumber::Messages::IdGenerator::Incrementing.new }
+
     def self.stubs(*names)
       names.each do |name|
         let(name) { double(name.to_s) }
@@ -171,8 +173,7 @@ module Cucumber::Core
       allow( visitor ).to receive(:test_suite).and_yield(visitor)
       allow( visitor ).to receive(:test_case).and_yield(visitor)
       yield visitor
-      super(gherkin_documents, visitor, [], EventBus.new)
+      super(gherkin_documents, visitor, [], EventBus.new, id_generator)
     end
-
   end
 end

--- a/spec/cucumber/core/filter_spec.rb
+++ b/spec/cucumber/core/filter_spec.rb
@@ -8,6 +8,8 @@ module Cucumber::Core
     include Cucumber::Core::Gherkin::Writer
     include Cucumber::Core
 
+    let(:id_generator) { Cucumber::Messages::IdGenerator::Incrementing.new }
+
     describe ".new" do
       let(:receiver) { double.as_null_object }
 
@@ -32,7 +34,7 @@ module Cucumber::Core
           expect(test_case.test_steps.length).to eq 1
           expect(test_case.test_steps.first.text).to eq 'a step'
         }.exactly(2).times
-        compile [doc], receiver, [my_filter], EventBus.new
+        compile [doc], receiver, [my_filter], EventBus.new, id_generator
       end
 
       context "customizing by subclassing" do
@@ -94,7 +96,7 @@ module Cucumber::Core
       end
 
       def run(filter)
-        compile [doc], receiver, [filter], EventBus.new
+        compile [doc], receiver, [filter], EventBus.new, id_generator
       end
     end
   end

--- a/spec/cucumber/core/filter_spec.rb
+++ b/spec/cucumber/core/filter_spec.rb
@@ -11,7 +11,7 @@ module Cucumber::Core
     describe ".new" do
       let(:receiver) { double.as_null_object }
 
-      let(:doc) { 
+      let(:doc) {
         gherkin do
           feature do
             scenario 'x' do
@@ -32,7 +32,7 @@ module Cucumber::Core
           expect(test_case.test_steps.length).to eq 1
           expect(test_case.test_steps.first.text).to eq 'a step'
         }.exactly(2).times
-        compile [doc], receiver, [my_filter]
+        compile [doc], receiver, [my_filter], EventBus.new
       end
 
       context "customizing by subclassing" do
@@ -46,7 +46,7 @@ module Cucumber::Core
           end
         end
 
-        # You can pass the names of attributes when building a 
+        # You can pass the names of attributes when building a
         # filter, allowing you to have custom attributes.
         class NamedBlankingFilter < Filter.new(:name_pattern)
           def test_case(test_case)
@@ -94,7 +94,7 @@ module Cucumber::Core
       end
 
       def run(filter)
-        compile [doc], receiver, [filter]
+        compile [doc], receiver, [filter], EventBus.new
       end
     end
   end

--- a/spec/cucumber/core/gherkin/parser_spec.rb
+++ b/spec/cucumber/core/gherkin/parser_spec.rb
@@ -14,6 +14,7 @@ module Cucumber
 
         before do
           allow( event_bus ).to receive(:gherkin_source_parsed)
+          allow( event_bus ).to receive(:pickle)
         end
 
         def parse
@@ -85,6 +86,12 @@ module Cucumber
 
           it "passes on the pickle" do
             expect( receiver ).to receive(:pickle)
+            parse
+          end
+
+          it "the pickle is sent through the event bus" do
+            expect( receiver ).to receive(:pickle)
+            expect( event_bus ).to receive(:pickle)
             parse
           end
         end

--- a/spec/cucumber/core/gherkin/parser_spec.rb
+++ b/spec/cucumber/core/gherkin/parser_spec.rb
@@ -9,7 +9,7 @@ module Cucumber
       describe Parser do
         let(:receiver)  { double }
         let(:event_bus) { double }
-        let(:parser)    { Parser.new(receiver, event_bus) }
+        let(:parser)    { Parser.new(receiver, event_bus, {}) }
         let(:visitor)   { double }
 
         before do

--- a/spec/cucumber/core/gherkin/parser_spec.rb
+++ b/spec/cucumber/core/gherkin/parser_spec.rb
@@ -14,7 +14,7 @@ module Cucumber
 
         before do
           allow( event_bus ).to receive(:gherkin_source_parsed)
-          allow( event_bus ).to receive(:pickle)
+          allow( event_bus ).to receive(:envelope)
         end
 
         def parse
@@ -91,9 +91,10 @@ module Cucumber
             parse
           end
 
-          it "the pickle is sent through the event bus" do
+          it "passes the pickle through the envelope event" do
             expect( receiver ).to receive(:pickle)
-            expect( event_bus ).to receive(:pickle)
+            expect( event_bus ).to receive(:envelope)
+
             parse
           end
         end

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -143,7 +143,7 @@ module Cucumber
             allow(receiver).to receive(:test_case) do |test_case|
               test_case_instances << test_case
             end
-            2.times { compile([gherkin], receiver, [], EventBus.new) }
+            2.times { compile([gherkin], receiver, [], EventBus.new, id_generator) }
             expect(test_case_instances.length).to eq 2
             expect(test_case_instances.uniq.length).to eq 1
             expect(test_case_instances[0]).to be_eql test_case_instances[1]

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -68,7 +68,7 @@ module Cucumber
           let(:test_steps) { [] }
 
           it 'includes the pickle id' do
-            expect(envelope.testCase.pickleId).to eq(pickle.id)
+            expect(envelope.test_case.pickle_id).to eq(pickle.id)
           end
         end
 

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -65,6 +65,7 @@ module Cucumber
 
         describe '#to_envelope' do
           let(:envelope) { test_case.to_envelope }
+          let(:test_steps) { [] }
 
           it 'includes the pickle id' do
             expect(envelope.testCase.pickleId).to eq(pickle.id)

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -68,6 +68,12 @@ module Cucumber
           end
         end
 
+        describe '#id' do
+          it "is generated on test case creation" do
+            expect( test_case.id ).not_to be_nil
+          end
+        end
+
         describe "matching tags" do
           let(:tags) { ['@a', '@b', '@c'].map { |value| Tag.new(location, value) } }
           it "matches tags using tag expressions" do

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -143,7 +143,7 @@ module Cucumber
             allow(receiver).to receive(:test_case) do |test_case|
               test_case_instances << test_case
             end
-            2.times { compile([gherkin], receiver) }
+            2.times { compile([gherkin], receiver, [], EventBus.new) }
             expect(test_case_instances.length).to eq 2
             expect(test_case_instances.uniq.length).to eq 1
             expect(test_case_instances[0]).to be_eql test_case_instances[1]

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -5,6 +5,7 @@ require 'cucumber/core/gherkin/writer'
 require 'cucumber/core/platform'
 require 'cucumber/core/test/case'
 require 'unindent'
+require 'cucumber/messages/id_generator'
 
 module Cucumber
   module Core
@@ -22,7 +23,10 @@ module Cucumber
           allow(p).to receive(:id).and_return('pickle-id')
           p
         }
+        let(:id_generator) { Cucumber::Messages::IdGenerator::Incrementing.new }
+
         let(:test_case) { Test::Case.new(
+          id_generator.new_id,
           pickle.id,
           name,
           test_steps,
@@ -58,7 +62,7 @@ module Cucumber
             expect( first_hook ).to receive(:describe_to).ordered.and_yield
             expect( second_hook ).to receive(:describe_to).ordered.and_yield
             around_hooks = [first_hook, second_hook]
-            Test::Case.new("pickle-id", name, [], location, tags, language, around_hooks).describe_to(visitor, double)
+            Test::Case.new(id_generator.new_id, "pickle-id", name, [], location, tags, language, around_hooks).describe_to(visitor, double)
           end
 
         end

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -23,6 +23,7 @@ module Cucumber
           p
         }
         let(:test_case) { Test::Case.new(
+          pickle.id,
           name,
           test_steps,
           location,
@@ -57,7 +58,7 @@ module Cucumber
             expect( first_hook ).to receive(:describe_to).ordered.and_yield
             expect( second_hook ).to receive(:describe_to).ordered.and_yield
             around_hooks = [first_hook, second_hook]
-            Test::Case.new(name, [], location, tags, language, around_hooks).describe_to(visitor, double)
+            Test::Case.new("pickle-id", name, [], location, tags, language, around_hooks).describe_to(visitor, double)
           end
 
         end

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -17,7 +17,19 @@ module Cucumber
         let(:location) { double }
         let(:tags) { double }
         let(:language) { double }
-        let(:test_case) { Test::Case.new(name, test_steps, location, tags, language) }
+        let(:pickle) {
+          p = double
+          allow(p).to receive(:id).and_return('pickle-id')
+          p
+        }
+        let(:test_case) { Test::Case.new(
+          name,
+          test_steps,
+          location,
+          tags,
+          language,
+          []
+        ) }
         let(:test_steps) { [double, double] }
 
         context 'describing itself' do
@@ -48,6 +60,14 @@ module Cucumber
             Test::Case.new(name, [], location, tags, language, around_hooks).describe_to(visitor, double)
           end
 
+        end
+
+        describe '#to_envelope' do
+          let(:envelope) { test_case.to_envelope }
+
+          it 'includes the pickle id' do
+            expect(envelope.testCase.pickleId).to eq(pickle.id)
+          end
         end
 
         describe "#name" do

--- a/spec/cucumber/core/test/filters/locations_filter_spec.rb
+++ b/spec/cucumber/core/test/filters/locations_filter_spec.rb
@@ -33,7 +33,7 @@ module Cucumber::Core
         Test::Location.new('features/test.feature', 3)
       ]
       filter = Test::LocationsFilter.new(locations)
-      compile [doc], receiver, [filter]
+      compile [doc], receiver, [filter], EventBus.new
       expect(receiver.test_case_locations).to eq locations
     end
 
@@ -42,7 +42,7 @@ module Cucumber::Core
         Test::Location.new('features/test.feature')
       ]
       filter = Test::LocationsFilter.new(locations)
-      compile [doc], receiver, [filter]
+      compile [doc], receiver, [filter], EventBus.new
       expect(receiver.test_case_locations).to eq [
         Test::Location.new('features/test.feature', 3),
         Test::Location.new('features/test.feature', 6)
@@ -54,7 +54,7 @@ module Cucumber::Core
         Test::Location.new('features/test.feature', 3)
       ]
       filter = Test::LocationsFilter.new(locations)
-      compile [doc], receiver, [filter]
+      compile [doc], receiver, [filter], EventBus.new
       expect(receiver.test_case_locations).to eq locations
     end
 
@@ -65,7 +65,7 @@ module Cucumber::Core
         receiver = double.as_null_object
         result = []
         allow(receiver).to receive(:test_case) { |test_case| result << test_case }
-        compile [doc], receiver
+        compile [doc], receiver, [], EventBus.new
         result
       end
 
@@ -108,7 +108,7 @@ module Cucumber::Core
         it 'matches the precise location of the scenario' do
           location = test_case_named('two').location
           filter = Test::LocationsFilter.new([location])
-          compile [doc], receiver, [filter]
+          compile [doc], receiver, [filter], EventBus.new
           expect(receiver.test_case_locations).to eq [test_case_named('two').location]
         end
 
@@ -116,21 +116,21 @@ module Cucumber::Core
           good_location = Test::Location.new(file, 8)
           bad_location = Test::Location.new(file, 5)
           filter = Test::LocationsFilter.new([good_location, bad_location])
-          compile [doc], receiver, [filter]
+          compile [doc], receiver, [filter], EventBus.new
           expect(receiver.test_case_locations).to eq [test_case_named('two').location]
         end
 
         it "doesn't match a location after the scenario line" do
           location = Test::Location.new(file, 9)
           filter = Test::LocationsFilter.new([location])
-          compile [doc], receiver, [filter]
+          compile [doc], receiver, [filter], EventBus.new
           expect(receiver.test_case_locations).to eq []
         end
 
         it "doesn't match a location before the scenario line" do
           location = Test::Location.new(file, 7)
           filter = Test::LocationsFilter.new([location])
-          compile [doc], receiver, [filter]
+          compile [doc], receiver, [filter], EventBus.new
           expect(receiver.test_case_locations).to eq []
         end
 
@@ -140,7 +140,7 @@ module Cucumber::Core
             location_tc_one = test_case_named('one').location
             location_last_step_tc_two = Test::Location.new(file, 10)
             filter = Test::LocationsFilter.new([location_tc_two, location_tc_one, location_last_step_tc_two])
-            compile [doc], receiver, [filter]
+            compile [doc], receiver, [filter], EventBus.new
             expect(receiver.test_case_locations).to eq [test_case_named('two').location, location_tc_one = test_case_named('one').location]
           end
         end
@@ -188,7 +188,7 @@ module Cucumber::Core
             Test::Location.new(file, 19),
           ]
           filter = Test::LocationsFilter.new(locations)
-          compile [doc], receiver, [filter]
+          compile [doc], receiver, [filter], EventBus.new
           expect(receiver.test_case_locations).to eq [test_case.location]
         end
 
@@ -197,14 +197,14 @@ module Cucumber::Core
             Test::Location.new(file, 8),
           ]
           filter = Test::LocationsFilter.new(locations)
-          compile [doc], receiver, [filter]
+          compile [doc], receiver, [filter], EventBus.new
           expect(receiver.test_case_locations.map(&:line)).to eq [19, 23, 24]
         end
 
         it "doesn't match the location of the examples line" do
           location = Test::Location.new(file, 17)
           filter = Test::LocationsFilter.new([location])
-          compile [doc], receiver, [filter]
+          compile [doc], receiver, [filter], EventBus.new
           expect(receiver.test_case_locations).to eq []
         end
       end
@@ -243,7 +243,7 @@ module Cucumber::Core
       it "filters #{num_features * num_scenarios_per_feature} test cases within #{max_duration_ms}ms" do
         filter = Test::LocationsFilter.new(locations)
         Timeout.timeout(max_duration_ms / 1000.0) do
-          compile docs, receiver, [filter]
+          compile docs, receiver, [filter], EventBus.new
         end
         expect(receiver.test_cases.length).to eq num_features * num_scenarios_per_feature
       end

--- a/spec/cucumber/core/test/runner_spec.rb
+++ b/spec/cucumber/core/test/runner_spec.rb
@@ -11,7 +11,7 @@ module Cucumber::Core::Test
     let(:location)  { double }
     let(:tags)      { double }
     let(:language)  { double }
-    let(:test_case) { Case.new(name, test_steps, location, tags, language) }
+    let(:test_case) { Case.new(name, test_steps, location, tags, language, []) }
     let(:text)      { double }
     let(:runner)    { Runner.new(event_bus) }
     let(:event_bus) { double.as_null_object }
@@ -223,8 +223,8 @@ module Cucumber::Core::Test
 
     context 'with multiple test cases' do
       context 'when the first test case fails' do
-        let(:first_test_case) { Case.new(name, [failing], location, tags, language) }
-        let(:last_test_case)  { Case.new(name, [passing], location, tags, language) }
+        let(:first_test_case) { Case.new(name, [failing], location, tags, language, []) }
+        let(:last_test_case)  { Case.new(name, [passing], location, tags, language, []) }
         let(:test_cases)      { [first_test_case, last_test_case] }
 
         it 'reports the results correctly for the following test case' do
@@ -246,7 +246,7 @@ module Cucumber::Core::Test
         end
         after_hook = HookStep.new(text, location, hook_mapping)
         failing_step = Step.new(text, location).with_action { fail }
-        test_case = Case.new(name, [failing_step, after_hook], location, tags, language)
+        test_case = Case.new(name, [failing_step, after_hook], location, tags, language, [])
         test_case.describe_to runner
         expect(result_spy).to be_failed
       end

--- a/spec/cucumber/core/test/runner_spec.rb
+++ b/spec/cucumber/core/test/runner_spec.rb
@@ -16,11 +16,11 @@ module Cucumber::Core::Test
     let(:text)      { double }
     let(:runner)    { Runner.new(event_bus) }
     let(:event_bus) { double.as_null_object }
-    let(:passing)   { Step.new(text, location, location).with_action {} }
-    let(:failing)   { Step.new(text, location, location).with_action { raise exception } }
-    let(:pending)   { Step.new(text, location, location).with_action { raise Result::Pending.new("TODO") } }
-    let(:skipping)  { Step.new(text, location, location).with_action { raise Result::Skipped.new } }
-    let(:undefined) { Step.new(text, location, location) }
+    let(:passing)   { Step.new(text, location, location, nil).with_action {} }
+    let(:failing)   { Step.new(text, location, location, nil).with_action { raise exception } }
+    let(:pending)   { Step.new(text, location, location, nil).with_action { raise Result::Pending.new("TODO") } }
+    let(:skipping)  { Step.new(text, location, location, nil).with_action { raise Result::Skipped.new } }
+    let(:undefined) { Step.new(text, location, location, nil) }
     let(:exception) { StandardError.new('test error') }
 
     before do
@@ -246,7 +246,7 @@ module Cucumber::Core::Test
           result_spy = last_result
         end
         after_hook = HookStep.new(text, location, hook_mapping)
-        failing_step = Step.new(text, location).with_action { fail }
+        failing_step = Step.new(text, location, nil, nil).with_action { fail }
         test_case = Case.new(pickle_id, name, [failing_step, after_hook], location, tags, language, [])
         test_case.describe_to runner
         expect(result_spy).to be_failed
@@ -257,7 +257,7 @@ module Cucumber::Core::Test
     context "with around hooks" do
       it "passes normally when around hooks don't fail" do
         around_hook = AroundHook.new { |block| block.call }
-        passing_step = Step.new(text, location, location).with_action {}
+        passing_step = Step.new(text, location, location, nil).with_action {}
         test_case = Case.new(pickle_id, name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_passed
@@ -267,7 +267,7 @@ module Cucumber::Core::Test
 
       it "gets a failed result if the Around hook fails before the test case is run" do
         around_hook = AroundHook.new { |block| raise exception }
-        passing_step = Step.new(text, location, location).with_action {}
+        passing_step = Step.new(text, location, location, nil).with_action {}
         test_case = Case.new(pickle_id, name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
@@ -278,7 +278,7 @@ module Cucumber::Core::Test
 
       it "gets a failed result if the Around hook fails after the test case is run" do
         around_hook = AroundHook.new { |block| block.call; raise exception }
-        passing_step = Step.new(text, location, location).with_action {}
+        passing_step = Step.new(text, location, location, nil).with_action {}
         test_case = Case.new(pickle_id, name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
@@ -289,7 +289,7 @@ module Cucumber::Core::Test
 
       it "fails when a step fails if the around hook works" do
         around_hook = AroundHook.new { |block| block.call }
-        failing_step = Step.new(text, location, location).with_action { raise exception }
+        failing_step = Step.new(text, location, location, nil).with_action { raise exception }
         test_case = Case.new(pickle_id, name, [failing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
@@ -300,7 +300,7 @@ module Cucumber::Core::Test
 
       it "sends after_test_step for a step interrupted by (a timeout in) the around hook" do
         around_hook = AroundHook.new { |block| block.call; raise exception }
-        passing_step = Step.new(text, location, location).with_action {}
+        passing_step = Step.new(text, location, location, nil).with_action {}
         test_case = Case.new(pickle_id, name, [], location, tags, language, [around_hook])
         allow(runner).to receive(:running_test_step).and_return(passing_step)
         expect(event_bus).to receive(:test_step_finished).with(passing_step, anything) do |reported_test_case, result|

--- a/spec/cucumber/core/test/runner_spec.rb
+++ b/spec/cucumber/core/test/runner_spec.rb
@@ -16,11 +16,11 @@ module Cucumber::Core::Test
     let(:text)      { double }
     let(:runner)    { Runner.new(event_bus) }
     let(:event_bus) { double.as_null_object }
-    let(:passing)   { Step.new(text, location, location, nil).with_action {} }
-    let(:failing)   { Step.new(text, location, location, nil).with_action { raise exception } }
-    let(:pending)   { Step.new(text, location, location, nil).with_action { raise Result::Pending.new("TODO") } }
-    let(:skipping)  { Step.new(text, location, location, nil).with_action { raise Result::Skipped.new } }
-    let(:undefined) { Step.new(text, location, location, nil) }
+    let(:passing)   { Step.new('', text, location, location, nil).with_action {} }
+    let(:failing)   { Step.new('', text, location, location, nil).with_action { raise exception } }
+    let(:pending)   { Step.new('', text, location, location, nil).with_action { raise Result::Pending.new("TODO") } }
+    let(:skipping)  { Step.new('', text, location, location, nil).with_action { raise Result::Skipped.new } }
+    let(:undefined) { Step.new('', text, location, location, nil) }
     let(:exception) { StandardError.new('test error') }
 
     before do
@@ -246,7 +246,7 @@ module Cucumber::Core::Test
           result_spy = last_result
         end
         after_hook = HookStep.new(text, location, hook_mapping)
-        failing_step = Step.new(text, location, nil, nil).with_action { fail }
+        failing_step = Step.new('', text, location, nil, nil).with_action { fail }
         test_case = Case.new(pickle_id, name, [failing_step, after_hook], location, tags, language, [])
         test_case.describe_to runner
         expect(result_spy).to be_failed
@@ -257,7 +257,7 @@ module Cucumber::Core::Test
     context "with around hooks" do
       it "passes normally when around hooks don't fail" do
         around_hook = AroundHook.new { |block| block.call }
-        passing_step = Step.new(text, location, location, nil).with_action {}
+        passing_step = Step.new('', text, location, location, nil).with_action {}
         test_case = Case.new(pickle_id, name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_passed
@@ -267,7 +267,7 @@ module Cucumber::Core::Test
 
       it "gets a failed result if the Around hook fails before the test case is run" do
         around_hook = AroundHook.new { |block| raise exception }
-        passing_step = Step.new(text, location, location, nil).with_action {}
+        passing_step = Step.new('', text, location, location, nil).with_action {}
         test_case = Case.new(pickle_id, name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
@@ -278,7 +278,7 @@ module Cucumber::Core::Test
 
       it "gets a failed result if the Around hook fails after the test case is run" do
         around_hook = AroundHook.new { |block| block.call; raise exception }
-        passing_step = Step.new(text, location, location, nil).with_action {}
+        passing_step = Step.new('', text, location, location, nil).with_action {}
         test_case = Case.new(pickle_id, name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
@@ -289,7 +289,7 @@ module Cucumber::Core::Test
 
       it "fails when a step fails if the around hook works" do
         around_hook = AroundHook.new { |block| block.call }
-        failing_step = Step.new(text, location, location, nil).with_action { raise exception }
+        failing_step = Step.new('', text, location, location, nil).with_action { raise exception }
         test_case = Case.new(pickle_id, name, [failing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
@@ -300,7 +300,7 @@ module Cucumber::Core::Test
 
       it "sends after_test_step for a step interrupted by (a timeout in) the around hook" do
         around_hook = AroundHook.new { |block| block.call; raise exception }
-        passing_step = Step.new(text, location, location, nil).with_action {}
+        passing_step = Step.new('', text, location, location, nil).with_action {}
         test_case = Case.new(pickle_id, name, [], location, tags, language, [around_hook])
         allow(runner).to receive(:running_test_step).and_return(passing_step)
         expect(event_bus).to receive(:test_step_finished).with(passing_step, anything) do |reported_test_case, result|

--- a/spec/cucumber/core/test/runner_spec.rb
+++ b/spec/cucumber/core/test/runner_spec.rb
@@ -245,7 +245,7 @@ module Cucumber::Core::Test
         hook_mapping = UnskippableAction.new do |last_result|
           result_spy = last_result
         end
-        after_hook = HookStep.new(text, location, hook_mapping)
+        after_hook = HookStep.new('', text, location, hook_mapping)
         failing_step = Step.new('', text, location, nil, nil).with_action { fail }
         test_case = Case.new(pickle_id, name, [failing_step, after_hook], location, tags, language, [])
         test_case.describe_to runner

--- a/spec/cucumber/core/test/runner_spec.rb
+++ b/spec/cucumber/core/test/runner_spec.rb
@@ -7,11 +7,12 @@ require 'cucumber/core/test/duration_matcher'
 module Cucumber::Core::Test
   describe Runner do
 
+    let(:pickle_id) { double }
     let(:name)      { double }
     let(:location)  { double }
     let(:tags)      { double }
     let(:language)  { double }
-    let(:test_case) { Case.new(name, test_steps, location, tags, language, []) }
+    let(:test_case) { Case.new(pickle_id, name, test_steps, location, tags, language, []) }
     let(:text)      { double }
     let(:runner)    { Runner.new(event_bus) }
     let(:event_bus) { double.as_null_object }
@@ -223,8 +224,8 @@ module Cucumber::Core::Test
 
     context 'with multiple test cases' do
       context 'when the first test case fails' do
-        let(:first_test_case) { Case.new(name, [failing], location, tags, language, []) }
-        let(:last_test_case)  { Case.new(name, [passing], location, tags, language, []) }
+        let(:first_test_case) { Case.new(pickle_id, name, [failing], location, tags, language, []) }
+        let(:last_test_case)  { Case.new(pickle_id, name, [passing], location, tags, language, []) }
         let(:test_cases)      { [first_test_case, last_test_case] }
 
         it 'reports the results correctly for the following test case' do
@@ -246,7 +247,7 @@ module Cucumber::Core::Test
         end
         after_hook = HookStep.new(text, location, hook_mapping)
         failing_step = Step.new(text, location).with_action { fail }
-        test_case = Case.new(name, [failing_step, after_hook], location, tags, language, [])
+        test_case = Case.new(pickle_id, name, [failing_step, after_hook], location, tags, language, [])
         test_case.describe_to runner
         expect(result_spy).to be_failed
       end
@@ -257,7 +258,7 @@ module Cucumber::Core::Test
       it "passes normally when around hooks don't fail" do
         around_hook = AroundHook.new { |block| block.call }
         passing_step = Step.new(text, location, location).with_action {}
-        test_case = Case.new(name, [passing_step], location, tags, language, [around_hook])
+        test_case = Case.new(pickle_id, name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_passed
         end
@@ -267,7 +268,7 @@ module Cucumber::Core::Test
       it "gets a failed result if the Around hook fails before the test case is run" do
         around_hook = AroundHook.new { |block| raise exception }
         passing_step = Step.new(text, location, location).with_action {}
-        test_case = Case.new(name, [passing_step], location, tags, language, [around_hook])
+        test_case = Case.new(pickle_id, name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
           expect(result.exception).to eq exception
@@ -278,7 +279,7 @@ module Cucumber::Core::Test
       it "gets a failed result if the Around hook fails after the test case is run" do
         around_hook = AroundHook.new { |block| block.call; raise exception }
         passing_step = Step.new(text, location, location).with_action {}
-        test_case = Case.new(name, [passing_step], location, tags, language, [around_hook])
+        test_case = Case.new(pickle_id, name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
           expect(result.exception).to eq exception
@@ -289,7 +290,7 @@ module Cucumber::Core::Test
       it "fails when a step fails if the around hook works" do
         around_hook = AroundHook.new { |block| block.call }
         failing_step = Step.new(text, location, location).with_action { raise exception }
-        test_case = Case.new(name, [failing_step], location, tags, language, [around_hook])
+        test_case = Case.new(pickle_id, name, [failing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
           expect(result.exception).to eq exception
@@ -300,7 +301,7 @@ module Cucumber::Core::Test
       it "sends after_test_step for a step interrupted by (a timeout in) the around hook" do
         around_hook = AroundHook.new { |block| block.call; raise exception }
         passing_step = Step.new(text, location, location).with_action {}
-        test_case = Case.new(name, [], location, tags, language, [around_hook])
+        test_case = Case.new(pickle_id, name, [], location, tags, language, [around_hook])
         allow(runner).to receive(:running_test_step).and_return(passing_step)
         expect(event_bus).to receive(:test_step_finished).with(passing_step, anything) do |reported_test_case, result|
           expect(result).to be_failed

--- a/spec/cucumber/core/test/step_spec.rb
+++ b/spec/cucumber/core/test/step_spec.rb
@@ -7,12 +7,16 @@ module Cucumber::Core::Test
     let(:location) { double }
 
     describe '#to_message' do
-      let(:step) { Step.new(text, location, nil, nil) }
+      let(:step) { Step.new("pickle-step-id", text, location, nil, nil) }
       let(:message) { step.to_message }
       let(:uuid_regex) { /[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/ }
 
       it 'outputs the step ID' do
         expect(message.id).to match(uuid_regex)
+      end
+
+      it 'outputs the pickleStepId' do
+        expect(message.pickleStepId).to eq('pickle-step-id')
       end
     end
 
@@ -20,7 +24,7 @@ module Cucumber::Core::Test
       it "describes itself to a visitor" do
         visitor = double
         args = double
-        test_step = Step.new(text, location, nil, nil)
+        test_step = Step.new('', text, location, nil, nil)
         expect( visitor ).to receive(:test_step).with(test_step, args)
         test_step.describe_to(visitor, args)
       end
@@ -29,7 +33,7 @@ module Cucumber::Core::Test
     describe "backtrace line" do
       let(:text) { 'this step passes' }
       let(:location)  { Location.new('path/file.feature', 10) }
-      let(:test_step) { Step.new(text, location, nil, nil) }
+      let(:test_step) { Step.new('', text, location, nil, nil) }
 
       it "knows how to form the backtrace line" do
         expect( test_step.backtrace_line ).to eq("path/file.feature:10:in `this step passes'")
@@ -40,7 +44,7 @@ module Cucumber::Core::Test
       it "passes arbitrary arguments to the action's block" do
         args_spy = nil
         expected_args = [double, double]
-        test_step = Step.new(text, location, nil, nil).with_action do |*actual_args|
+        test_step = Step.new('', text, location, nil, nil).with_action do |*actual_args|
           args_spy = actual_args
         end
         test_step.execute(*expected_args)
@@ -49,7 +53,7 @@ module Cucumber::Core::Test
 
       context "when a passing action exists" do
         it "returns a passing result" do
-          test_step = Step.new(text, location, nil, nil).with_action {}
+          test_step = Step.new('', text, location, nil, nil).with_action {}
           expect( test_step.execute ).to be_passed
         end
       end
@@ -58,7 +62,7 @@ module Cucumber::Core::Test
         let(:exception) { StandardError.new('oops') }
 
         it "returns a failing result" do
-          test_step = Step.new(text, location, nil, nil).with_action { raise exception }
+          test_step = Step.new('', text, location, nil, nil).with_action { raise exception }
           result = test_step.execute
           expect( result           ).to be_failed
           expect( result.exception ).to eq exception
@@ -67,7 +71,7 @@ module Cucumber::Core::Test
 
       context "with no action" do
         it "returns an Undefined result" do
-          test_step = Step.new(text, location, nil, nil)
+          test_step = Step.new('', text, location, nil, nil)
           result = test_step.execute
           expect( result           ).to be_undefined
         end
@@ -75,7 +79,7 @@ module Cucumber::Core::Test
     end
 
     it "exposes the text and location of as attributes" do
-      test_step = Step.new(text, location, nil, nil)
+      test_step = Step.new('', text, location, nil, nil)
       expect( test_step.text              ).to eq text
       expect( test_step.location          ).to eq location
     end
@@ -83,13 +87,13 @@ module Cucumber::Core::Test
     it "exposes the location of the action as attribute" do
       location = double
       action = double(location: location)
-      test_step = Step.new(text, location, nil, action)
+      test_step = Step.new('', text, location, nil, action)
       expect( test_step.action_location ).to eq location
     end
 
     it "returns the text when converted to a string" do
       text = 'a passing step'
-      test_step = Step.new(text, location, nil, nil)
+      test_step = Step.new('', text, location, nil, nil)
       expect( test_step.to_s     ).to eq 'a passing step'
     end
   end

--- a/spec/cucumber/core/test/step_spec.rb
+++ b/spec/cucumber/core/test/step_spec.rb
@@ -6,6 +6,11 @@ module Cucumber::Core::Test
     let(:text) { 'step text' }
     let(:location) { double }
 
+    it 'has a unique id' do
+      test_step = Step.new(text, location)
+      expect(test_step.id).not_to be_nil
+    end
+
     describe "describing itself" do
       it "describes itself to a visitor" do
         visitor = double
@@ -82,6 +87,5 @@ module Cucumber::Core::Test
       test_step = Step.new(text, location)
       expect( test_step.to_s     ).to eq 'a passing step'
     end
-
   end
 end

--- a/spec/cucumber/core/test/step_spec.rb
+++ b/spec/cucumber/core/test/step_spec.rb
@@ -6,16 +6,21 @@ module Cucumber::Core::Test
     let(:text) { 'step text' }
     let(:location) { double }
 
-    it 'has a unique id' do
-      test_step = Step.new(text, location)
-      expect(test_step.id).not_to be_nil
+    describe '#to_message' do
+      let(:step) { Step.new(text, location, nil, nil) }
+      let(:message) { step.to_message }
+      let(:uuid_regex) { /[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/ }
+
+      it 'outputs the step ID' do
+        expect(message.id).to match(uuid_regex)
+      end
     end
 
     describe "describing itself" do
       it "describes itself to a visitor" do
         visitor = double
         args = double
-        test_step = Step.new(text, location)
+        test_step = Step.new(text, location, nil, nil)
         expect( visitor ).to receive(:test_step).with(test_step, args)
         test_step.describe_to(visitor, args)
       end
@@ -24,7 +29,7 @@ module Cucumber::Core::Test
     describe "backtrace line" do
       let(:text) { 'this step passes' }
       let(:location)  { Location.new('path/file.feature', 10) }
-      let(:test_step) { Step.new(text, location) }
+      let(:test_step) { Step.new(text, location, nil, nil) }
 
       it "knows how to form the backtrace line" do
         expect( test_step.backtrace_line ).to eq("path/file.feature:10:in `this step passes'")
@@ -35,7 +40,7 @@ module Cucumber::Core::Test
       it "passes arbitrary arguments to the action's block" do
         args_spy = nil
         expected_args = [double, double]
-        test_step = Step.new(text, location).with_action do |*actual_args|
+        test_step = Step.new(text, location, nil, nil).with_action do |*actual_args|
           args_spy = actual_args
         end
         test_step.execute(*expected_args)
@@ -44,7 +49,7 @@ module Cucumber::Core::Test
 
       context "when a passing action exists" do
         it "returns a passing result" do
-          test_step = Step.new(text, location).with_action {}
+          test_step = Step.new(text, location, nil, nil).with_action {}
           expect( test_step.execute ).to be_passed
         end
       end
@@ -53,7 +58,7 @@ module Cucumber::Core::Test
         let(:exception) { StandardError.new('oops') }
 
         it "returns a failing result" do
-          test_step = Step.new(text, location).with_action { raise exception }
+          test_step = Step.new(text, location, nil, nil).with_action { raise exception }
           result = test_step.execute
           expect( result           ).to be_failed
           expect( result.exception ).to eq exception
@@ -62,7 +67,7 @@ module Cucumber::Core::Test
 
       context "with no action" do
         it "returns an Undefined result" do
-          test_step = Step.new(text, location)
+          test_step = Step.new(text, location, nil, nil)
           result = test_step.execute
           expect( result           ).to be_undefined
         end
@@ -70,7 +75,7 @@ module Cucumber::Core::Test
     end
 
     it "exposes the text and location of as attributes" do
-      test_step = Step.new(text, location)
+      test_step = Step.new(text, location, nil, nil)
       expect( test_step.text              ).to eq text
       expect( test_step.location          ).to eq location
     end
@@ -78,13 +83,13 @@ module Cucumber::Core::Test
     it "exposes the location of the action as attribute" do
       location = double
       action = double(location: location)
-      test_step = Step.new(text, location, action)
+      test_step = Step.new(text, location, nil, action)
       expect( test_step.action_location ).to eq location
     end
 
     it "returns the text when converted to a string" do
       text = 'a passing step'
-      test_step = Step.new(text, location)
+      test_step = Step.new(text, location, nil, nil)
       expect( test_step.to_s     ).to eq 'a passing step'
     end
   end

--- a/spec/cucumber/core/test/step_spec.rb
+++ b/spec/cucumber/core/test/step_spec.rb
@@ -97,4 +97,15 @@ module Cucumber::Core::Test
       expect( test_step.to_s     ).to eq 'a passing step'
     end
   end
+
+  describe HookStep do
+    context '#to_message' do
+      let(:step) { HookStep.new('hook-id', 'some-text', nil, nil) }
+      let(:message) { step.to_message}
+
+      it 'provides the Hook id' do
+        expect(message.hookId).to eq('hook-id')
+      end
+    end
+  end
 end

--- a/spec/cucumber/core/test/step_spec.rb
+++ b/spec/cucumber/core/test/step_spec.rb
@@ -16,7 +16,7 @@ module Cucumber::Core::Test
       end
 
       it 'outputs the pickleStepId' do
-        expect(message.pickleStepId).to eq('pickle-step-id')
+        expect(message.pickle_step_id).to eq('pickle-step-id')
       end
     end
 

--- a/spec/cucumber/core_spec.rb
+++ b/spec/cucumber/core_spec.rb
@@ -33,7 +33,7 @@ module Cucumber
               end
             end
           end
-        ], visitor)
+        ], visitor, [], Core::EventBus.new)
 
         expect( visitor.messages ).to eq [
           :test_case,
@@ -75,7 +75,7 @@ module Cucumber
           end
         end
 
-        compile [gherkin], visitor, [Cucumber::Core::Test::TagFilter.new(['@a', '@b'])]
+        compile [gherkin], visitor, [Cucumber::Core::Test::TagFilter.new(['@a', '@b'])], Core::EventBus.new
       end
     end
 

--- a/spec/cucumber/core_spec.rb
+++ b/spec/cucumber/core_spec.rb
@@ -100,7 +100,7 @@ module Cucumber
         end
 
         observed_events = []
-        execute [gherkin], [Core::Test::Filters::ActivateStepsForSelfTest.new] do |event_bus|
+        execute [gherkin], [Core::Test::Filters::ActivateStepsForSelfTest.new], Core::EventBus.new do |event_bus|
           event_bus.on(:test_case_started) do |event|
             test_case = event.test_case
             observed_events << [:test_case_started, test_case.name]

--- a/spec/cucumber/core_spec.rb
+++ b/spec/cucumber/core_spec.rb
@@ -170,7 +170,7 @@ module Cucumber
       context "with around hooks" do
         class WithAroundHooks < Core::Filter.new(:logger)
           def test_case(test_case)
-            base_step = Core::Test::Step.new('text', nil, nil, nil)
+            base_step = Core::Test::Step.new('', 'text', nil, nil, nil)
             test_steps = [
               base_step.with_action { logger << :step },
             ]

--- a/spec/cucumber/core_spec.rb
+++ b/spec/cucumber/core_spec.rb
@@ -13,6 +13,8 @@ module Cucumber
     include Core
     include Core::Gherkin::Writer
 
+    let(:id_generator) { Cucumber::Messages::IdGenerator::Incrementing.new }
+
     describe "compiling features to a test suite" do
 
       it "compiles two scenarios into two test cases" do
@@ -33,7 +35,7 @@ module Cucumber
               end
             end
           end
-        ], visitor, [], Core::EventBus.new)
+        ], visitor, [], Core::EventBus.new, id_generator)
 
         expect( visitor.messages ).to eq [
           :test_case,
@@ -75,7 +77,7 @@ module Cucumber
           end
         end
 
-        compile [gherkin], visitor, [Cucumber::Core::Test::TagFilter.new(['@a', '@b'])], Core::EventBus.new
+        compile [gherkin], visitor, [Cucumber::Core::Test::TagFilter.new(['@a', '@b'])], Core::EventBus.new, id_generator
       end
     end
 

--- a/spec/cucumber/core_spec.rb
+++ b/spec/cucumber/core_spec.rb
@@ -100,7 +100,7 @@ module Cucumber
         end
 
         observed_events = []
-        execute [gherkin], [Core::Test::Filters::ActivateStepsForSelfTest.new], Core::EventBus.new do |event_bus|
+        execute [gherkin], [Core::Test::Filters::ActivateStepsForSelfTest.new], Core::EventBus.new, id_generator do |event_bus|
           event_bus.on(:test_case_started) do |event|
             test_case = event.test_case
             observed_events << [:test_case_started, test_case.name]
@@ -156,7 +156,7 @@ module Cucumber
 
           event_bus = Core::EventBus.new
           report = Core::Report::Summary.new(event_bus)
-          execute [gherkin], [Core::Test::Filters::ActivateStepsForSelfTest.new], event_bus
+          execute [gherkin], [Core::Test::Filters::ActivateStepsForSelfTest.new], event_bus, id_generator
 
           expect( report.test_cases.total           ).to eq 2
           expect( report.test_cases.total_passed    ).to eq 1
@@ -201,7 +201,7 @@ module Cucumber
 
           event_bus = Core::EventBus.new
           report = Core::Report::Summary.new(event_bus)
-          execute [gherkin], [WithAroundHooks.new(logger)], event_bus
+          execute [gherkin], [WithAroundHooks.new(logger)], event_bus, id_generator
 
           expect( report.test_cases.total        ).to eq 1
           expect( report.test_cases.total_passed ).to eq 1
@@ -236,7 +236,7 @@ module Cucumber
 
         event_bus = Core::EventBus.new
         report = Core::Report::Summary.new(event_bus)
-        execute [gherkin], [ Cucumber::Core::Test::TagFilter.new(['@a']) ], event_bus
+        execute [gherkin], [ Cucumber::Core::Test::TagFilter.new(['@a']) ], event_bus, id_generator
 
         expect( report.test_cases.total ).to eq 2
       end
@@ -255,7 +255,7 @@ module Cucumber
 
         event_bus = Core::EventBus.new
         report = Core::Report::Summary.new(event_bus)
-        execute [gherkin], [ Cucumber::Core::Test::NameFilter.new([/scenario/]) ], event_bus
+        execute [gherkin], [ Cucumber::Core::Test::NameFilter.new([/scenario/]) ], event_bus, id_generator
 
         expect( report.test_cases.total ).to eq 1
       end

--- a/spec/cucumber/core_spec.rb
+++ b/spec/cucumber/core_spec.rb
@@ -170,7 +170,8 @@ module Cucumber
       context "with around hooks" do
         class WithAroundHooks < Core::Filter.new(:logger)
           def test_case(test_case)
-            base_step = Core::Test::Step.new('', 'text', nil, nil, nil)
+            id_generator = Cucumber::Messages::IdGenerator::Incrementing.new
+            base_step = Core::Test::Step.new(id_generator.new_id, '', 'text', nil, nil, nil)
             test_steps = [
               base_step.with_action { logger << :step },
             ]


### PR DESCRIPTION
## Summary

Add support for `--format=protobuf` in Cucumber Ruby.

Still WIP for now :)

## Details

The idea is to produce messages using the `protocol buffer` library so we can use stand alone formatters.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
