### PR TITLE
CI: Use jruby-9.2.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ matrix:
     - rvm: 2.5
     - rvm: 2.4
     - rvm: 2.3
-    - rvm: jruby-9.2.8.0
+    - rvm: jruby-9.2.9.0
       env: JRUBY_OPTS="--debug" LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8
   allow_failures:
     - rvm: ruby-head
     # https://github.com/cucumber/cucumber-ruby/issues/1336
-    - rvm: jruby-9.2.8.0
+    - rvm: jruby-9.2.9.0
 
   fast_finish: true


### PR DESCRIPTION
## Summary

CI: Use jruby-9.2.9.0.

## Details

A new version was released.

## Motivation and Context


Some of the --add-opens would be less necessary to include, now.

## How Has This Been Tested?

Only in CI.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
