### PR TITLE
Cucumber messages 7.0

### DIFF
--- a/lib/cucumber/core/gherkin/location_query.rb
+++ b/lib/cucumber/core/gherkin/location_query.rb
@@ -19,23 +19,29 @@ module Cucumber
         end
 
         def pickle_locations(pickle)
-          scenario = scenario_by_id[pickle.sourceIds[0]]
-          table_row = table_row_by_id[pickle.sourceIds[1]]
-          locations = []
-
-          locations << scenario.location if scenario
-          locations << table_row.location if table_row
-          locations
+          [
+            scenario_by_id[pickle.sourceIds[0]],
+            table_row_by_id[pickle.sourceIds[1]]
+          ].compact.map(&:location)
         end
 
         def pickle_step_locations(pickle_step)
-          scenario_step = scenario_step_by_id[pickle_step.sourceIds[0]]
-          table_row = table_row_by_id[pickle_step.sourceIds[1]]
-          locations = []
+          [
+            scenario_step_by_id[pickle_step.sourceIds[0]],
+            table_row_by_id[pickle_step.sourceIds[1]]
+          ].compact.map(&:location)
+        end
 
-          locations << scenario_step.location if scenario_step
-          locations << table_row.location if table_row
-          locations
+        def pickle_step_argument_location(pickle_step)
+          scenario_step = scenario_step_by_id[pickle_step.sourceIds[0]]
+          if scenario_step
+            case scenario_step.argument
+            when :doc_string
+              return scenario_step.doc_string.location
+            when :data_table
+              return scenario_step.data_table.location
+            end
+          end
         end
 
         def pickle_tag_location(pickle_tag)
@@ -54,7 +60,7 @@ module Cucumber
         def process_children(children)
           children.each do |children|
             process_scenario(children.scenario) if children.scenario
-            process_children(children.rule.children) if children.rule
+            process_children(children.rule.children) if children.respond_to?(:rule) && children.rule
           end
         end
 

--- a/lib/cucumber/core/gherkin/location_query.rb
+++ b/lib/cucumber/core/gherkin/location_query.rb
@@ -58,9 +58,9 @@ module Cucumber
         end
 
         def process_children(children)
-          children.each do |children|
-            process_scenario(children.scenario) if children.scenario
-            process_children(children.rule.children) if children.respond_to?(:rule) && children.rule
+          children.each do |child|
+            process_scenario(child.scenario) if child.scenario
+            process_children(child.rule.children) if child.respond_to?(:rule) && child.rule
           end
         end
 

--- a/lib/cucumber/core/gherkin/location_query.rb
+++ b/lib/cucumber/core/gherkin/location_query.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+# Note: this may move to cucumber-query later on
+
+module Cucumber
+  module Core
+    module Gherkin
+      class LocationQuery
+        def process(message)
+          if message.gherkinDocument
+            process_gherkin_document(message.gherkinDocument)
+          elsif message.pickle
+            process_pickle(message.pickle)
+          end
+        end
+
+        def pickles
+          @pickles ||= []
+        end
+
+        def pickle_locations(pickle)
+          scenario = scenario_by_id[pickle.sourceIds[0]]
+          table_row = table_row_by_id[pickle.sourceIds[1]]
+          locations = []
+
+          locations << scenario.location if scenario
+          locations << table_row.location if table_row
+          locations
+        end
+
+        def pickle_step_locations(pickle_step)
+          scenario_step = scenario_step_by_id[pickle_step.sourceIds[0]]
+          table_row = table_row_by_id[pickle_step.sourceIds[1]]
+          locations = []
+
+          locations << scenario_step.location if scenario_step
+          locations << table_row.location if table_row
+          locations
+        end
+
+        def pickle_tag_location(pickle_tag)
+          tag_by_id[pickle_tag.sourceId].location
+        end
+
+        private
+
+        def process_gherkin_document(document)
+          if document.feature
+            process_children(document.feature.children)
+            process_tags(document.feature.tags)
+          end
+        end
+
+        def process_children(children)
+          children.each do |children|
+            process_scenario(children.scenario) if children.scenario
+            process_children(children.rule.children) if children.rule
+          end
+        end
+
+        def process_scenario(scenario)
+          scenario_by_id[scenario.id] = scenario
+          process_tags(scenario.tags)
+          scenario.steps.each do |step|
+            scenario_step_by_id[step.id] = step
+          end
+          process_examples(scenario.examples) if scenario.examples
+        end
+
+        def process_examples(examples)
+          examples.each do |example|
+            process_tags(example.tags)
+            example.table_body.each do |table_row|
+              table_row_by_id[table_row.id] = table_row
+            end
+          end
+        end
+
+        def process_tags(tags)
+          tags.each do |tag|
+            tag_by_id[tag.id] = tag
+          end
+        end
+
+        def process_pickle(pickle)
+          pickles << pickle
+        end
+
+        def scenario_by_id
+          @scenario_by_id ||= {}
+        end
+
+        def scenario_step_by_id
+          @scenario_step_by_id ||= {}
+        end
+
+        def table_row_by_id
+          @table_row_by_id ||= {}
+        end
+
+        def tag_by_id
+          @tag_by_id ||= {}
+        end
+      end
+    end
+  end
+end

--- a/spec/cucumber/core/gherkin/location_query_spec.rb
+++ b/spec/cucumber/core/gherkin/location_query_spec.rb
@@ -1,0 +1,120 @@
+# -*- encoding: utf-8 -*-
+# frozen_string_literal: true
+require 'cucumber/core/gherkin/location_query'
+require 'gherkin'
+
+module Cucumber
+  module Core
+    module Gherkin
+      describe LocationQuery do
+        let(:subject) {
+          lq = LocationQuery.new
+          messages.each do |message|
+            lq.process(message)
+          end
+          lq
+        }
+
+        let(:content) {
+          <<-FEATURE
+            Feature: my simple feature
+
+            Scenario: A scenario
+              Given a passed step
+            FEATURE
+        }
+
+        let(:messages) { ::Gherkin.from_source(
+          'some.feature',
+          content, {
+            include_gherkin_document: true,
+            include_pickles: true
+          }
+        )}
+
+        let(:pickle) {
+          subject.pickles.first
+        }
+
+        describe 'pickle_locations' do
+          it 'returns the Location of source scenario' do
+            location = subject.pickle_locations(pickle).first
+
+            expect(location.line).to eq(3)
+          end
+
+          context 'when generated from a Examples table' do
+            let(:content) {
+              <<-FEATURE
+                Feature: my simple feature
+
+                Scenario: A scenario
+                  Given a <status> step
+
+                Examples:
+                   | status |
+                   | passed |
+                   | failed |
+                FEATURE
+            }
+
+            it 'returns the Locations of the source scenario and example used' do
+              locations = subject.pickle_locations(pickle)
+
+              expect(locations[0].line).to eq(3)
+              expect(locations[1].line).to eq(8)
+            end
+          end
+        end
+
+        describe 'pickle_step_locations' do
+          let(:pickle_step) { pickle.steps.first }
+
+          it 'returns the Location of the scenario step' do
+            expect(subject.pickle_step_locations(pickle_step).first.line).to eq(4)
+          end
+
+          context 'when generated from a Examples table' do
+            let(:content) {
+              <<-FEATURE
+                Feature: my simple feature
+
+                Scenario: A scenario
+                  Given a <status> step
+
+                Examples:
+                   | status |
+                   | passed |
+                   | failed |
+                FEATURE
+            }
+
+            it 'returns the Locations of the scenario step and example used' do
+              locations = subject.pickle_step_locations(pickle_step)
+
+              expect(locations[0].line).to eq(4)
+              expect(locations[1].line).to eq(8)
+            end
+          end
+        end
+
+        describe 'pickle_tag_location' do
+          let(:content) {
+            <<-FEATURE
+            Feature:  With tags
+
+              @acceptance
+              Scenario: With a single tag
+                Given a passed step
+              FEATURE
+          }
+          let(:pickle_tag) { pickle.tags.first }
+
+          it 'returns the Location of the tag' do
+            expect(subject.pickle_tag_location(pickle_tag).line).to eq(3)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cucumber/core/gherkin/location_query_spec.rb
+++ b/spec/cucumber/core/gherkin/location_query_spec.rb
@@ -98,6 +98,51 @@ module Cucumber
           end
         end
 
+        describe 'pickle_step_argument_location' do
+          let(:pickle_step) { pickle.steps.first }
+
+          context 'when there is a docstring argument' do
+            let(:content) {
+              <<-FEATURE
+                Feature: my simple feature
+
+                Scenario: A scenario
+                  Given a passed step
+                    """
+                    This is my DocString
+                    """
+                FEATURE
+            }
+
+            it 'returns the location of the doc string' do
+              expect(subject.pickle_step_argument_location(pickle_step).line).to eq(5)
+            end
+          end
+
+          context 'when there is a datatable argument' do
+            let(:content) {
+              <<-FEATURE
+                Feature: my simple feature
+
+                Scenario: A scenario
+                  Given a passed step
+                  | name | value |
+                  | plic | ploc  |
+                FEATURE
+            }
+
+            it 'returns the location of the datatable' do
+              expect(subject.pickle_step_argument_location(pickle_step).line).to eq(5)
+            end
+          end
+
+          context 'when there is no argument' do
+            it 'returns nil' do
+              expect(subject.pickle_step_argument_location(pickle_step)).to be_nil
+            end
+          end
+        end
+
         describe 'pickle_tag_location' do
           let(:content) {
             <<-FEATURE

--- a/spec/cucumber/core/gherkin/parser_spec.rb
+++ b/spec/cucumber/core/gherkin/parser_spec.rb
@@ -69,7 +69,9 @@ module Cucumber
           end
 
           it "the pickles have the correct language" do
-            expect( receiver ).to receive(:pickle).with(pickle_with_language('ja'))
+            expect( receiver )
+              .to receive(:pickle)
+              .with(pickle_with_language('ja'), kind_of(LocationQuery))
             parse
           end
         end


### PR DESCRIPTION
## Summary

The release of `cucumber-messages` removed the `Location` property on many messages (`Pickle`, `PickleStep`etc) which were used when computing messages in `cucumber-ruby(-core)`.

## How Has This Been Tested?

I've added a few test for the `LocationQuery` object.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
