### PR TITLE
Force cucumber-message version to 6.x

### DIFF
--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
                   }
 
   s.add_dependency 'gherkin', '~> 8.1', '>= 8.1.1'
+  s.add_dependency 'cucumber-messages', '~> 6.0'
   s.add_dependency 'cucumber-tag_expressions', '~> 2.0', '>= 2.0.2'
   s.add_dependency 'backports', '~> 3.15', '>= 3.15.0'
 


### PR DESCRIPTION
## Summary

Until we can support `cucumber-messages` 7, we'll force the use of the 6.0 releases.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
