### PR TITLE
Remove backports dependency

### DIFF
--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'gherkin', '~> 8.1', '>= 8.1.1'
   s.add_dependency 'cucumber-messages', '~> 6.0'
   s.add_dependency 'cucumber-tag_expressions', '~> 2.0', '>= 2.0.2'
-  s.add_dependency 'backports', '~> 3.15', '>= 3.15.0'
 
   s.add_development_dependency 'coveralls', '~> 0.8', '>= 0.8.23'
   s.add_development_dependency 'rake', '~> 12.3', '>= 12.3.3'

--- a/lib/cucumber/core/event.rb
+++ b/lib/cucumber/core/event.rb
@@ -1,5 +1,3 @@
-require 'backports/2.1.0/array/to_h'
-
 module Cucumber
   module Core
     class Event
@@ -24,7 +22,7 @@ module Cucumber
           end
 
           define_method(:to_h) do
-            attributes.reduce({}) { |result, attribute| 
+            attributes.reduce({}) { |result, attribute|
               value = self.send(attribute)
               result[attribute] = value
               result


### PR DESCRIPTION
Since the gem requires Ruby 2.3+ there's no need for the backports gem.
It's also quite large and takes up 1191 files on disk, which is a
wonderfuly nasty performance hit on windows where requiring files is
slow.

Signed-off-by: Tim Smith <tsmith@chef.io>