### PR TITLE
Use Gherkin::Query and Gherkin 9+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem 'gherkin', path: ENV['GHERKIN_RUBY'] if ENV['GHERKIN_RUBY']
-
 gem 'cucumber-messages', path: ENV['CUCUMBER_MESSAGES_RUBY'] if ENV['CUCUMBER_MESSAGES_RUBY']
 
 # Use an older protobuf on JRuby

--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
                     'source_code_uri' => 'https://github.com/cucumber/cucumber-ruby-core',
                   }
 
-  s.add_dependency 'gherkin', '~> 8.1', '>= 8.1.1'
-  s.add_dependency 'cucumber-messages', '~> 6.0'
+  s.add_dependency 'gherkin', '~> 9.0', '>= 9.0.0'
+  s.add_dependency 'cucumber-messages', '~> 8.0'
   s.add_dependency 'cucumber-tag_expressions', '~> 2.0', '>= 2.0.2'
   s.add_dependency 'backports', '~> 3.15', '>= 3.15.0'
 

--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
                     'source_code_uri' => 'https://github.com/cucumber/cucumber-ruby-core',
                   }
 
-  s.add_dependency 'gherkin', '~> 9.0', '>= 9.0.0'
-  s.add_dependency 'cucumber-messages', '~> 8.0'
+  s.add_dependency 'cucumber-gherkin', '~> 9.1', '>= 9.1.0'
+  s.add_dependency 'cucumber-messages', '~> 9.0', '>= 9.0.3'
   s.add_dependency 'cucumber-tag_expressions', '~> 2.0', '>= 2.0.2'
   s.add_dependency 'backports', '~> 3.15', '>= 3.15.0'
 

--- a/lib/cucumber/core.rb
+++ b/lib/cucumber/core.rb
@@ -4,6 +4,7 @@ require 'cucumber/core/gherkin/parser'
 require 'cucumber/core/gherkin/document'
 require 'cucumber/core/compiler'
 require 'cucumber/core/test/runner'
+require 'gherkin/query'
 
 module Cucumber
   module Core
@@ -17,15 +18,16 @@ module Cucumber
 
     def compile(gherkin_documents, last_receiver, filters = [], event_bus = EventBus.new)
       first_receiver = compose(filters, last_receiver)
-      compiler = Compiler.new(first_receiver)
-      parse gherkin_documents, compiler, event_bus
+      gherkin_query = ::Gherkin::Query.new
+      compiler = Compiler.new(first_receiver, gherkin_query)
+      parse gherkin_documents, compiler, event_bus, gherkin_query
       self
     end
 
     private
 
-    def parse(gherkin_documents, compiler, event_bus)
-      parser = Core::Gherkin::Parser.new(compiler, event_bus)
+    def parse(gherkin_documents, compiler, event_bus, gherkin_query)
+      parser = Core::Gherkin::Parser.new(compiler, event_bus, gherkin_query)
       gherkin_documents.each do |document|
         parser.document document
       end

--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -47,19 +47,16 @@ module Cucumber
 
       def create_multiline_arg(pickle_step, uri)
         if pickle_step.argument
-          argument_line =source_line_for_pickle_step_argument(pickle_step)
           if pickle_step.argument.doc_string
             doc_string = pickle_step.argument.doc_string
             Test::DocString.new(
               doc_string.content,
-              doc_string.media_type,
-              Test::Location.new(uri, argument_line)
+              doc_string.media_type
             )
           elsif pickle_step.argument.data_table
             data_table = pickle_step.argument.data_table
             Test::DataTable.new(
-              data_table.rows.map { |row| row.cells.map { |cell| cell.value } },
-              Test::Location.new(uri, argument_line)
+              data_table.rows.map { |row| row.cells.map { |cell| cell.value } }
             )
           end
         else
@@ -77,10 +74,6 @@ module Cucumber
 
       def source_line_for_pickle_tag(tag)
         source_line(tag.ast_node_id)
-      end
-
-      def source_line_for_pickle_step_argument(pickle_step)
-        gherkin_query.argument_location(pickle_step.ast_node_ids[0])
       end
 
       def source_line(id)

--- a/lib/cucumber/core/test/data_table.rb
+++ b/lib/cucumber/core/test/data_table.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'cucumber/core/test/location'
 
 module Cucumber
   module Core
@@ -24,18 +23,15 @@ module Cucumber
       # This will store <tt>[['a', 'b'], ['c', 'd']]</tt> in the <tt>data</tt> variable.
       #
       class DataTable
-        include HasLocation
-
         # Creates a new instance. +raw+ should be an Array of Array of String
         # or an Array of Hash
         # You don't typically create your own DataTable objects - Cucumber will do
         # it internally and pass them to your Step Definitions.
         #
-        def initialize(rows, location)
+        def initialize(rows)
           raw = ensure_array_of_array(rows)
           verify_rows_are_same_length(raw)
           @raw = raw.freeze
-          @location = location
         end
         attr_reader :raw
 
@@ -58,7 +54,7 @@ module Cucumber
         # Creates a copy of this table
         #
         def dup
-          self.class.new(raw.dup, location)
+          self.class.new(raw.dup)
         end
 
         # Returns a new, transposed table. Example:
@@ -73,7 +69,7 @@ module Cucumber
         #   | 4 | 2 |
         #
         def transpose
-          self.class.new(raw.transpose, location)
+          self.class.new(raw.transpose)
         end
 
         def map(&block)
@@ -81,7 +77,7 @@ module Cucumber
             row.map(&block)
           end
 
-          self.class.new(new_raw, location)
+          self.class.new(new_raw)
         end
 
         def ==(other)
@@ -89,7 +85,7 @@ module Cucumber
         end
 
         def inspect
-          %{#<#{self.class} #{raw.inspect} (#{location})>}
+          %{#<#{self.class} #{raw.inspect})>}
         end
 
         private

--- a/lib/cucumber/core/test/doc_string.rb
+++ b/lib/cucumber/core/test/doc_string.rb
@@ -20,14 +20,11 @@ module Cucumber
       # Note how the indentation from the source is stripped away.
       #
       class DocString < SimpleDelegator
-        include HasLocation
-
         attr_reader :content_type, :content
 
-        def initialize(content, content_type, location)
+        def initialize(content, content_type)
           @content = content
           @content_type = content_type
-          @location = location
           super @content
         end
 
@@ -46,7 +43,7 @@ module Cucumber
         def map
           raise ArgumentError, "No block given" unless block_given?
           new_content = yield content
-          self.class.new(new_content, content_type, location)
+          self.class.new(new_content, content_type)
         end
 
         def to_step_definition_arg
@@ -65,7 +62,7 @@ module Cucumber
 
         def inspect
           [
-            %{#<#{self.class} (#{location})},
+            %{#<#{self.class}},
             %{  """#{content_type}},
             %{  #{@content}},
             %{  """>}

--- a/spec/cucumber/core/gherkin/parser_spec.rb
+++ b/spec/cucumber/core/gherkin/parser_spec.rb
@@ -9,11 +9,13 @@ module Cucumber
       describe Parser do
         let(:receiver)  { double }
         let(:event_bus) { double }
-        let(:parser)    { Parser.new(receiver, event_bus) }
+        let(:gherkin_query) { double }
+        let(:parser)    { Parser.new(receiver, event_bus, gherkin_query) }
         let(:visitor)   { double }
 
         before do
           allow( event_bus ).to receive(:gherkin_source_parsed)
+          allow( gherkin_query ).to receive(:update)
         end
 
         def parse

--- a/spec/cucumber/core/test/data_table_spec.rb
+++ b/spec/cucumber/core/test/data_table_spec.rb
@@ -6,31 +6,29 @@ module Cucumber
   module Core
     module Test
       describe DataTable do
-        let(:location) { Test::Location.new('foo.feature', 9..12) }
-
         before do
           @table = DataTable.new([
             %w{one four seven},
             %w{4444 55555 666666}
-          ], location)
+          ])
         end
 
         describe "equality" do
           it "is equal to another table with the same data" do
-            expect( DataTable.new([[1,2],[3,4]], location) ).to eq DataTable.new([[1,2],[3,4]], location)
+            expect( DataTable.new([[1,2],[3,4]]) ).to eq DataTable.new([[1,2],[3,4]])
           end
 
           it "is not equal to another table with different data" do
-            expect( DataTable.new([[1,2],[3,4]], location) ).not_to eq DataTable.new([[1,2]], location)
+            expect( DataTable.new([[1,2],[3,4]]) ).not_to eq DataTable.new([[1,2]])
           end
 
           it "is not equal to a non table" do
-            expect( DataTable.new([[1,2],[3,4]], location) ).not_to eq Object.new
+            expect( DataTable.new([[1,2],[3,4]]) ).not_to eq Object.new
           end
         end
 
         describe "#data_table?" do
-          let(:table) { DataTable.new([[1,2],[3,4]], location) }
+          let(:table) { DataTable.new([[1,2],[3,4]]) }
 
           it "returns true" do
             expect(table).to be_data_table
@@ -38,7 +36,7 @@ module Cucumber
         end
 
         describe "#doc_string" do
-          let(:table) { DataTable.new([[1,2],[3,4]], location) }
+          let(:table) { DataTable.new([[1,2],[3,4]]) }
 
           it "returns false" do
             expect(table).not_to be_doc_string
@@ -46,7 +44,7 @@ module Cucumber
         end
 
         describe "#map" do
-          let(:table) { DataTable.new([ %w{foo bar}, %w{1 2} ], location) }
+          let(:table) { DataTable.new([ %w{foo bar}, %w{1 2} ]) }
 
           it 'yields the contents of each cell to the block' do
 
@@ -54,7 +52,7 @@ module Cucumber
           end
 
           it 'returns a new table with the cells modified by the block' do
-            expect( table.map { |cell| "*#{cell}*" } ).to eq  DataTable.new([%w{*foo* *bar*}, %w{*1* *2*}], location)
+            expect( table.map { |cell| "*#{cell}*" } ).to eq  DataTable.new([%w{*foo* *bar*}, %w{*1* *2*}])
           end
         end
 
@@ -63,14 +61,14 @@ module Cucumber
             @table = DataTable.new([
               %w{one 1111},
               %w{two 22222}
-            ], location)
+            ])
           end
 
           it "should transpose the table" do
             transposed = DataTable.new([
               %w{one two},
               %w{1111 22222}
-            ], location)
+            ])
             expect( @table.transpose ).to eq( transposed )
           end
         end

--- a/spec/cucumber/core/test/doc_string_spec.rb
+++ b/spec/cucumber/core/test/doc_string_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'cucumber/core/test/location'
 require 'cucumber/core/test/doc_string'
 require 'unindent'
 
@@ -7,11 +6,10 @@ module Cucumber
   module Core
     module Test
       describe DocString do
-        let(:location) { double }
-        let(:doc_string) { DocString.new(content, content_type, location) }
+        let(:doc_string) { DocString.new(content, content_type) }
 
         describe "#data_table?" do
-          let(:doc_string) { DocString.new("test", "text/plain" , location) }
+          let(:doc_string) { DocString.new("test", "text/plain" ) }
 
           it "returns false" do
             expect(doc_string).not_to be_data_table
@@ -19,7 +17,7 @@ module Cucumber
         end
 
         describe "#doc_string" do
-          let(:doc_string) { DocString.new("test", "text/plain" , location) }
+          let(:doc_string) { DocString.new("test", "text/plain" ) }
 
           it "returns true" do
             expect(doc_string).to be_doc_string
@@ -48,15 +46,15 @@ module Cucumber
           let(:content_type) { 'text/plain' }
 
           it 'is equal to another DocString with the same content and content_type' do
-            expect( doc_string ).to eq DocString.new(content, content_type, location)
+            expect( doc_string ).to eq DocString.new(content, content_type)
           end
 
           it 'is not equal to another DocString with different content' do
-            expect( doc_string ).not_to eq DocString.new('bar', content_type, location)
+            expect( doc_string ).not_to eq DocString.new('bar', content_type)
           end
 
           it 'is not equal to another DocString with different content_type' do
-            expect( doc_string ).not_to eq DocString.new(content, 'text/html', location)
+            expect( doc_string ).not_to eq DocString.new(content, 'text/html')
           end
 
           it 'is equal to a string with the same content' do
@@ -96,13 +94,12 @@ module Cucumber
       end
 
       context "inspect" do
-        let(:location) { Test::Location.new("features/feature.feature", 8) }
         let(:content_type) { 'text/plain' }
 
         it "provides a useful inspect method" do
-          doc_string = DocString.new("some text", content_type, location)
+          doc_string = DocString.new("some text", content_type)
           expect(doc_string.inspect).to eq <<-END.chomp.unindent
-          #<Cucumber::Core::Test::DocString (features/feature.feature:8)
+          #<Cucumber::Core::Test::DocString
             """text/plain
             some text
             """>


### PR DESCRIPTION
## Summary

This PR bumps Gherkin to version 9 and uses the `Gherkin::Query` object to locate lines of elements from the feature files.

It will need the [monorepo#845](https://github.com/cucumber/cucumber/pull/845) to be merged/released in order to get it working.

## How Has This Been Tested?

Using existing tests suite.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
