### PR TITLE
[Spike] Use event bus to map element ids

### DIFF
--- a/lib/cucumber/core.rb
+++ b/lib/cucumber/core.rb
@@ -4,6 +4,7 @@ require 'cucumber/core/gherkin/parser'
 require 'cucumber/core/gherkin/document'
 require 'cucumber/core/compiler'
 require 'cucumber/core/test/runner'
+require 'cucumber/core/id_generator'
 
 module Cucumber
   module Core
@@ -17,7 +18,7 @@ module Cucumber
 
     def compile(gherkin_documents, last_receiver, filters = [], event_bus = EventBus.new)
       first_receiver = compose(filters, last_receiver)
-      compiler = Compiler.new(first_receiver)
+      compiler = Compiler.new(first_receiver, IdGenerator::Incrementing.new)
       parse gherkin_documents, compiler, event_bus
       self
     end

--- a/lib/cucumber/core.rb
+++ b/lib/cucumber/core.rb
@@ -18,7 +18,7 @@ module Cucumber
 
     def compile(gherkin_documents, last_receiver, filters = [], event_bus = EventBus.new)
       first_receiver = compose(filters, last_receiver)
-      compiler = Compiler.new(first_receiver, IdGenerator::Incrementing.new)
+      compiler = Compiler.new(first_receiver, IdGenerator::Incrementing.new, event_bus)
       parse gherkin_documents, compiler, event_bus
       self
     end

--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -14,9 +14,10 @@ module Cucumber
       attr_reader :receiver, :id_generator
       private     :receiver, :id_generator
 
-      def initialize(receiver, id_generator)
+      def initialize(receiver, id_generator, event_bus = nil)
         @receiver = receiver
         @id_generator = id_generator
+        @event_bus = event_bus
       end
 
       def pickle(pickle)
@@ -36,13 +37,17 @@ module Cucumber
         test_steps = pickle.steps.map { |step| create_test_step(step, uri) }
         lines = pickle.locations.map { |location| location.line }.sort.reverse
         tags = pickle.tags.map { |tag| Test::Tag.new(Test::Location.new(uri, tag.location.line), tag.name) }
-        Test::Case.new(id_generator.new_id, pickle.name, test_steps, Test::Location.new(uri, lines), tags, pickle.language)
+        test_case = Test::Case.new(id_generator.new_id, pickle.name, test_steps, Test::Location.new(uri, lines), tags, pickle.language)
+        @event_bus.broadcast(Events::TestCaseCreated.new(test_case, pickle)) unless @event_bus.nil?
+        test_case
       end
 
       def create_test_step(pickle_step, uri)
         lines = pickle_step.locations.map { |location| location.line }.sort.reverse
         multiline_arg = create_multiline_arg(pickle_step, uri)
-        Test::Step.new(id_generator.new_id, pickle_step.text, Test::Location.new(uri, lines), multiline_arg)
+        step = Test::Step.new(id_generator.new_id, pickle_step.text, Test::Location.new(uri, lines), multiline_arg)
+        @event_bus.broadcast(Events::TestStepCreated.new(step, pickle_step)) unless @event_bus.nil?
+        step
       end
 
       def create_multiline_arg(pickle_step, uri)

--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -36,7 +36,7 @@ module Cucumber
         test_steps = pickle.steps.map { |step| create_test_step(step, uri) }
         lines = pickle.locations.map { |location| location.line }.sort.reverse
         tags = pickle.tags.map { |tag| Test::Tag.new(Test::Location.new(uri, tag.location.line), tag.name) }
-        Test::Case.new(pickle.name, test_steps, Test::Location.new(uri, lines), tags, pickle.language)
+        Test::Case.new(id_generator.new_id, pickle.name, test_steps, Test::Location.new(uri, lines), tags, pickle.language)
       end
 
       def create_test_step(pickle_step, uri)

--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -11,11 +11,12 @@ module Cucumber
   module Core
     # Compiles the Pickles into test cases
     class Compiler
-      attr_reader :receiver
-      private     :receiver
+      attr_reader :receiver, :id_generator
+      private     :receiver, :id_generator
 
-      def initialize(receiver)
+      def initialize(receiver, id_generator)
         @receiver = receiver
+        @id_generator = id_generator
       end
 
       def pickle(pickle)
@@ -41,7 +42,7 @@ module Cucumber
       def create_test_step(pickle_step, uri)
         lines = pickle_step.locations.map { |location| location.line }.sort.reverse
         multiline_arg = create_multiline_arg(pickle_step, uri)
-        Test::Step.new(pickle_step.text, Test::Location.new(uri, lines), multiline_arg)
+        Test::Step.new(id_generator.new_id, pickle_step.text, Test::Location.new(uri, lines), multiline_arg)
       end
 
       def create_multiline_arg(pickle_step, uri)

--- a/lib/cucumber/core/events.rb
+++ b/lib/cucumber/core/events.rb
@@ -12,6 +12,24 @@ module Cucumber
 
       end
 
+      # Signals that a Test::Step was created from a PickleStep
+      class TestStepCreated < Event.new(:test_step, :pickle_step)
+        # The created test step
+        attr_reader :test_step
+
+        # The source pickle step
+        attr_reader :pickle_step
+      end
+
+      # Signals that a Test::Case was created from a Pickle
+      class TestCaseCreated < Event.new(:test_case, :pickle)
+        # The created test step
+        attr_reader :test_case
+
+        # The source pickle step
+        attr_reader :pickle
+      end
+
       # Signals that a {Test::Case} is about to be executed
       class TestCaseStarted < Event.new(:test_case)
 
@@ -56,6 +74,8 @@ module Cucumber
       def self.registry
         build_registry(
           GherkinSourceParsed,
+          TestStepCreated,
+          TestCaseCreated,
           TestCaseStarted,
           TestStepStarted,
           TestStepFinished,

--- a/lib/cucumber/core/id_generator.rb
+++ b/lib/cucumber/core/id_generator.rb
@@ -1,0 +1,18 @@
+# This is temporary - we'll use the IDGenerator that built-in cucumber-messages
+
+module Cucumber
+  module Core
+    module IdGenerator
+      class Incrementing
+        def initialize
+          @index = -1
+        end
+
+        def new_id
+          @index += 1
+          @index.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/cucumber/core/report/message.rb
+++ b/lib/cucumber/core/report/message.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+module Cucumber
+  module Core
+    module Report
+      class Message
+        def initialize(event_bus)
+          @pickle_step_by_step_id = {}
+          @pickle_by_test_case_id = {}
+          subscribe_to(event_bus)
+        end
+
+        private
+
+        def subscribe_to(event_bus)
+          event_bus.on(:test_step_created) do |event|
+            @pickle_step_by_step_id[event.test_step.id] = event.pickle_step
+          end
+
+          event_bus.on(:test_case_created) do |event|
+            @pickle_by_test_case_id[event.test_case.id] = event.pickle
+          end
+
+          event_bus.on(:test_run_started) do |event|
+            puts "Know pickles and steps"
+            puts "Pickles:"
+            puts  @pickle_by_test_case_id.map {|id, pickle| " - #{id} - #{pickle}"}.join("\n")
+
+            puts "Pickle steps:"
+            puts  @pickle_step_by_step_id.map {|id, pickle_step| " - #{id} - #{pickle_step}"}.join("\n")
+
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -7,10 +7,11 @@ module Cucumber
   module Core
     module Test
       class Case
-        attr_reader :name, :test_steps, :location, :tags, :language, :around_hooks
+        attr_reader :id, :name, :test_steps, :location, :tags, :language, :around_hooks
 
-        def initialize(name, test_steps, location, tags, language, around_hooks = [])
+        def initialize(id, name, test_steps, location, tags, language, around_hooks = [])
           raise ArgumentError.new("test_steps should be an Array but is a #{test_steps.class}") unless test_steps.is_a?(Array)
+          @id = id
           @name = name
           @test_steps = test_steps
           @location = location
@@ -35,11 +36,11 @@ module Cucumber
         end
 
         def with_steps(test_steps)
-          self.class.new(name, test_steps, location, tags, language, around_hooks)
+          self.class.new(id, name, test_steps, location, tags, language, around_hooks)
         end
 
         def with_around_hooks(around_hooks)
-          self.class.new(name, test_steps, location, tags, language, around_hooks)
+          self.class.new(id, name, test_steps, location, tags, language, around_hooks)
         end
 
         def match_tags?(*expressions)

--- a/lib/cucumber/core/test/step.rb
+++ b/lib/cucumber/core/test/step.rb
@@ -8,10 +8,11 @@ module Cucumber
   module Core
     module Test
       class Step
-        attr_reader :text, :location, :multiline_arg
+        attr_reader :id, :text, :location, :multiline_arg
 
-        def initialize(text, location, multiline_arg = Test::EmptyMultilineArgument.new, action = Test::UndefinedAction.new(location))
+        def initialize(id, text, location, multiline_arg = Test::EmptyMultilineArgument.new, action = Test::UndefinedAction.new(location))
           raise ArgumentError if text.nil? || text.empty?
+          @id = id
           @text = text
           @location = location
           @multiline_arg = multiline_arg
@@ -35,7 +36,7 @@ module Cucumber
         end
 
         def with_action(action_location = nil, &block)
-          self.class.new(text, location, multiline_arg, Test::Action.new(action_location, &block))
+          self.class.new(id, text, location, multiline_arg, Test::Action.new(action_location, &block))
         end
 
         def backtrace_line
@@ -56,8 +57,8 @@ module Cucumber
       end
 
       class HookStep < Step
-        def initialize(text, location, action)
-          super(text, location, Test::EmptyMultilineArgument.new, action)
+        def initialize(id, text, location, action)
+          super(id, text, location, Test::EmptyMultilineArgument.new, action)
         end
 
         def hook?

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -17,7 +17,7 @@ module Cucumber
         let(:location) { double }
         let(:tags) { double }
         let(:language) { double }
-        let(:test_case) { Test::Case.new(name, test_steps, location, tags, language) }
+        let(:test_case) { Test::Case.new('some-random-uid', name, test_steps, location, tags, language) }
         let(:test_steps) { [double, double] }
 
         context 'describing itself' do
@@ -45,7 +45,7 @@ module Cucumber
             expect( first_hook ).to receive(:describe_to).ordered.and_yield
             expect( second_hook ).to receive(:describe_to).ordered.and_yield
             around_hooks = [first_hook, second_hook]
-            Test::Case.new(name, [], location, tags, language, around_hooks).describe_to(visitor, double)
+            Test::Case.new('some-random-uid', name, [], location, tags, language, around_hooks).describe_to(visitor, double)
           end
 
         end

--- a/spec/cucumber/core/test/case_spec.rb
+++ b/spec/cucumber/core/test/case_spec.rb
@@ -13,11 +13,12 @@ module Cucumber
         include Core
         include Core::Gherkin::Writer
 
+        let(:id) { double }
         let(:name) { double }
         let(:location) { double }
         let(:tags) { double }
         let(:language) { double }
-        let(:test_case) { Test::Case.new('some-random-uid', name, test_steps, location, tags, language) }
+        let(:test_case) { Test::Case.new(id, name, test_steps, location, tags, language) }
         let(:test_steps) { [double, double] }
 
         context 'describing itself' do
@@ -45,7 +46,7 @@ module Cucumber
             expect( first_hook ).to receive(:describe_to).ordered.and_yield
             expect( second_hook ).to receive(:describe_to).ordered.and_yield
             around_hooks = [first_hook, second_hook]
-            Test::Case.new('some-random-uid', name, [], location, tags, language, around_hooks).describe_to(visitor, double)
+            Test::Case.new(id, name, [], location, tags, language, around_hooks).describe_to(visitor, double)
           end
 
         end

--- a/spec/cucumber/core/test/runner_spec.rb
+++ b/spec/cucumber/core/test/runner_spec.rb
@@ -15,11 +15,11 @@ module Cucumber::Core::Test
     let(:text)      { double }
     let(:runner)    { Runner.new(event_bus) }
     let(:event_bus) { double.as_null_object }
-    let(:passing)   { Step.new(text, location, location).with_action {} }
-    let(:failing)   { Step.new(text, location, location).with_action { raise exception } }
-    let(:pending)   { Step.new(text, location, location).with_action { raise Result::Pending.new("TODO") } }
-    let(:skipping)  { Step.new(text, location, location).with_action { raise Result::Skipped.new } }
-    let(:undefined) { Step.new(text, location, location) }
+    let(:passing)   { Step.new('some-random-uid', text, location, location).with_action {} }
+    let(:failing)   { Step.new('some-random-uid', text, location, location).with_action { raise exception } }
+    let(:pending)   { Step.new('some-random-uid', text, location, location).with_action { raise Result::Pending.new("TODO") } }
+    let(:skipping)  { Step.new('some-random-uid', text, location, location).with_action { raise Result::Skipped.new } }
+    let(:undefined) { Step.new('some-random-uid', text, location, location) }
     let(:exception) { StandardError.new('test error') }
 
     before do
@@ -244,8 +244,8 @@ module Cucumber::Core::Test
         hook_mapping = UnskippableAction.new do |last_result|
           result_spy = last_result
         end
-        after_hook = HookStep.new(text, location, hook_mapping)
-        failing_step = Step.new(text, location).with_action { fail }
+        after_hook = HookStep.new('some-random-uid', text, location, hook_mapping)
+        failing_step = Step.new('some-random-uid', text, location).with_action { fail }
         test_case = Case.new(name, [failing_step, after_hook], location, tags, language)
         test_case.describe_to runner
         expect(result_spy).to be_failed
@@ -256,7 +256,7 @@ module Cucumber::Core::Test
     context "with around hooks" do
       it "passes normally when around hooks don't fail" do
         around_hook = AroundHook.new { |block| block.call }
-        passing_step = Step.new(text, location, location).with_action {}
+        passing_step = Step.new('some-random-uid', text, location, location).with_action {}
         test_case = Case.new(name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_passed
@@ -266,7 +266,7 @@ module Cucumber::Core::Test
 
       it "gets a failed result if the Around hook fails before the test case is run" do
         around_hook = AroundHook.new { |block| raise exception }
-        passing_step = Step.new(text, location, location).with_action {}
+        passing_step = Step.new('some-random-uid', text, location, location).with_action {}
         test_case = Case.new(name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
@@ -277,7 +277,7 @@ module Cucumber::Core::Test
 
       it "gets a failed result if the Around hook fails after the test case is run" do
         around_hook = AroundHook.new { |block| block.call; raise exception }
-        passing_step = Step.new(text, location, location).with_action {}
+        passing_step = Step.new('some-random-uid', text, location, location).with_action {}
         test_case = Case.new(name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
@@ -288,7 +288,7 @@ module Cucumber::Core::Test
 
       it "fails when a step fails if the around hook works" do
         around_hook = AroundHook.new { |block| block.call }
-        failing_step = Step.new(text, location, location).with_action { raise exception }
+        failing_step = Step.new('some-random-uid', text, location, location).with_action { raise exception }
         test_case = Case.new(name, [failing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
@@ -299,7 +299,7 @@ module Cucumber::Core::Test
 
       it "sends after_test_step for a step interrupted by (a timeout in) the around hook" do
         around_hook = AroundHook.new { |block| block.call; raise exception }
-        passing_step = Step.new(text, location, location).with_action {}
+        passing_step = Step.new('some-random-uid', text, location, location).with_action {}
         test_case = Case.new(name, [], location, tags, language, [around_hook])
         allow(runner).to receive(:running_test_step).and_return(passing_step)
         expect(event_bus).to receive(:test_step_finished).with(passing_step, anything) do |reported_test_case, result|

--- a/spec/cucumber/core/test/runner_spec.rb
+++ b/spec/cucumber/core/test/runner_spec.rb
@@ -11,7 +11,7 @@ module Cucumber::Core::Test
     let(:location)  { double }
     let(:tags)      { double }
     let(:language)  { double }
-    let(:test_case) { Case.new(name, test_steps, location, tags, language) }
+    let(:test_case) { Case.new('random-test-uid', name, test_steps, location, tags, language) }
     let(:text)      { double }
     let(:runner)    { Runner.new(event_bus) }
     let(:event_bus) { double.as_null_object }
@@ -223,8 +223,8 @@ module Cucumber::Core::Test
 
     context 'with multiple test cases' do
       context 'when the first test case fails' do
-        let(:first_test_case) { Case.new(name, [failing], location, tags, language) }
-        let(:last_test_case)  { Case.new(name, [passing], location, tags, language) }
+        let(:first_test_case) { Case.new('random-test-uid', name, [failing], location, tags, language) }
+        let(:last_test_case)  { Case.new('random-test-uid', name, [passing], location, tags, language) }
         let(:test_cases)      { [first_test_case, last_test_case] }
 
         it 'reports the results correctly for the following test case' do
@@ -246,7 +246,7 @@ module Cucumber::Core::Test
         end
         after_hook = HookStep.new('some-random-uid', text, location, hook_mapping)
         failing_step = Step.new('some-random-uid', text, location).with_action { fail }
-        test_case = Case.new(name, [failing_step, after_hook], location, tags, language)
+        test_case = Case.new('random-test-uid', name, [failing_step, after_hook], location, tags, language)
         test_case.describe_to runner
         expect(result_spy).to be_failed
       end
@@ -257,7 +257,7 @@ module Cucumber::Core::Test
       it "passes normally when around hooks don't fail" do
         around_hook = AroundHook.new { |block| block.call }
         passing_step = Step.new('some-random-uid', text, location, location).with_action {}
-        test_case = Case.new(name, [passing_step], location, tags, language, [around_hook])
+        test_case = Case.new('random-test-uid', name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_passed
         end
@@ -267,7 +267,7 @@ module Cucumber::Core::Test
       it "gets a failed result if the Around hook fails before the test case is run" do
         around_hook = AroundHook.new { |block| raise exception }
         passing_step = Step.new('some-random-uid', text, location, location).with_action {}
-        test_case = Case.new(name, [passing_step], location, tags, language, [around_hook])
+        test_case = Case.new('random-test-uid', name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
           expect(result.exception).to eq exception
@@ -278,7 +278,7 @@ module Cucumber::Core::Test
       it "gets a failed result if the Around hook fails after the test case is run" do
         around_hook = AroundHook.new { |block| block.call; raise exception }
         passing_step = Step.new('some-random-uid', text, location, location).with_action {}
-        test_case = Case.new(name, [passing_step], location, tags, language, [around_hook])
+        test_case = Case.new('random-test-uid', name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
           expect(result.exception).to eq exception
@@ -289,7 +289,7 @@ module Cucumber::Core::Test
       it "fails when a step fails if the around hook works" do
         around_hook = AroundHook.new { |block| block.call }
         failing_step = Step.new('some-random-uid', text, location, location).with_action { raise exception }
-        test_case = Case.new(name, [failing_step], location, tags, language, [around_hook])
+        test_case = Case.new('random-test-uid', name, [failing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
           expect(result.exception).to eq exception
@@ -300,7 +300,7 @@ module Cucumber::Core::Test
       it "sends after_test_step for a step interrupted by (a timeout in) the around hook" do
         around_hook = AroundHook.new { |block| block.call; raise exception }
         passing_step = Step.new('some-random-uid', text, location, location).with_action {}
-        test_case = Case.new(name, [], location, tags, language, [around_hook])
+        test_case = Case.new('random-test-uid', name, [], location, tags, language, [around_hook])
         allow(runner).to receive(:running_test_step).and_return(passing_step)
         expect(event_bus).to receive(:test_step_finished).with(passing_step, anything) do |reported_test_case, result|
           expect(result).to be_failed

--- a/spec/cucumber/core/test/runner_spec.rb
+++ b/spec/cucumber/core/test/runner_spec.rb
@@ -7,19 +7,21 @@ require 'cucumber/core/test/duration_matcher'
 module Cucumber::Core::Test
   describe Runner do
 
+    let(:step_id)   { double }
+    let(:test_id)   { double }
     let(:name)      { double }
     let(:location)  { double }
     let(:tags)      { double }
     let(:language)  { double }
-    let(:test_case) { Case.new('random-test-uid', name, test_steps, location, tags, language) }
+    let(:test_case) { Case.new(test_id, name, test_steps, location, tags, language) }
     let(:text)      { double }
     let(:runner)    { Runner.new(event_bus) }
     let(:event_bus) { double.as_null_object }
-    let(:passing)   { Step.new('some-random-uid', text, location, location).with_action {} }
-    let(:failing)   { Step.new('some-random-uid', text, location, location).with_action { raise exception } }
-    let(:pending)   { Step.new('some-random-uid', text, location, location).with_action { raise Result::Pending.new("TODO") } }
-    let(:skipping)  { Step.new('some-random-uid', text, location, location).with_action { raise Result::Skipped.new } }
-    let(:undefined) { Step.new('some-random-uid', text, location, location) }
+    let(:passing)   { Step.new(step_id, text, location, location).with_action {} }
+    let(:failing)   { Step.new(step_id, text, location, location).with_action { raise exception } }
+    let(:pending)   { Step.new(step_id, text, location, location).with_action { raise Result::Pending.new("TODO") } }
+    let(:skipping)  { Step.new(step_id, text, location, location).with_action { raise Result::Skipped.new } }
+    let(:undefined) { Step.new(step_id, text, location, location) }
     let(:exception) { StandardError.new('test error') }
 
     before do
@@ -223,8 +225,8 @@ module Cucumber::Core::Test
 
     context 'with multiple test cases' do
       context 'when the first test case fails' do
-        let(:first_test_case) { Case.new('random-test-uid', name, [failing], location, tags, language) }
-        let(:last_test_case)  { Case.new('random-test-uid', name, [passing], location, tags, language) }
+        let(:first_test_case) { Case.new(test_id, name, [failing], location, tags, language) }
+        let(:last_test_case)  { Case.new(test_id, name, [passing], location, tags, language) }
         let(:test_cases)      { [first_test_case, last_test_case] }
 
         it 'reports the results correctly for the following test case' do
@@ -244,9 +246,9 @@ module Cucumber::Core::Test
         hook_mapping = UnskippableAction.new do |last_result|
           result_spy = last_result
         end
-        after_hook = HookStep.new('some-random-uid', text, location, hook_mapping)
-        failing_step = Step.new('some-random-uid', text, location).with_action { fail }
-        test_case = Case.new('random-test-uid', name, [failing_step, after_hook], location, tags, language)
+        after_hook = HookStep.new(step_id, text, location, hook_mapping)
+        failing_step = Step.new(step_id, text, location).with_action { fail }
+        test_case = Case.new(test_id, name, [failing_step, after_hook], location, tags, language)
         test_case.describe_to runner
         expect(result_spy).to be_failed
       end
@@ -256,8 +258,8 @@ module Cucumber::Core::Test
     context "with around hooks" do
       it "passes normally when around hooks don't fail" do
         around_hook = AroundHook.new { |block| block.call }
-        passing_step = Step.new('some-random-uid', text, location, location).with_action {}
-        test_case = Case.new('random-test-uid', name, [passing_step], location, tags, language, [around_hook])
+        passing_step = Step.new(step_id, text, location, location).with_action {}
+        test_case = Case.new(test_id, name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_passed
         end
@@ -266,8 +268,8 @@ module Cucumber::Core::Test
 
       it "gets a failed result if the Around hook fails before the test case is run" do
         around_hook = AroundHook.new { |block| raise exception }
-        passing_step = Step.new('some-random-uid', text, location, location).with_action {}
-        test_case = Case.new('random-test-uid', name, [passing_step], location, tags, language, [around_hook])
+        passing_step = Step.new(step_id, text, location, location).with_action {}
+        test_case = Case.new(test_id, name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
           expect(result.exception).to eq exception
@@ -277,8 +279,8 @@ module Cucumber::Core::Test
 
       it "gets a failed result if the Around hook fails after the test case is run" do
         around_hook = AroundHook.new { |block| block.call; raise exception }
-        passing_step = Step.new('some-random-uid', text, location, location).with_action {}
-        test_case = Case.new('random-test-uid', name, [passing_step], location, tags, language, [around_hook])
+        passing_step = Step.new(step_id, text, location, location).with_action {}
+        test_case = Case.new(test_id, name, [passing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
           expect(result.exception).to eq exception
@@ -288,8 +290,8 @@ module Cucumber::Core::Test
 
       it "fails when a step fails if the around hook works" do
         around_hook = AroundHook.new { |block| block.call }
-        failing_step = Step.new('some-random-uid', text, location, location).with_action { raise exception }
-        test_case = Case.new('random-test-uid', name, [failing_step], location, tags, language, [around_hook])
+        failing_step = Step.new(step_id, text, location, location).with_action { raise exception }
+        test_case = Case.new(test_id, name, [failing_step], location, tags, language, [around_hook])
         expect(event_bus).to receive(:test_case_finished).with(test_case, anything) do |reported_test_case, result|
           expect(result).to be_failed
           expect(result.exception).to eq exception
@@ -299,8 +301,8 @@ module Cucumber::Core::Test
 
       it "sends after_test_step for a step interrupted by (a timeout in) the around hook" do
         around_hook = AroundHook.new { |block| block.call; raise exception }
-        passing_step = Step.new('some-random-uid', text, location, location).with_action {}
-        test_case = Case.new('random-test-uid', name, [], location, tags, language, [around_hook])
+        passing_step = Step.new(step_id, text, location, location).with_action {}
+        test_case = Case.new(test_id, name, [], location, tags, language, [around_hook])
         allow(runner).to receive(:running_test_step).and_return(passing_step)
         expect(event_bus).to receive(:test_step_finished).with(passing_step, anything) do |reported_test_case, result|
           expect(result).to be_failed

--- a/spec/cucumber/core/test/step_spec.rb
+++ b/spec/cucumber/core/test/step_spec.rb
@@ -3,6 +3,7 @@ require 'cucumber/core/test/step'
 
 module Cucumber::Core::Test
   describe Step do
+    let(:id) { 'some-random-uid' }
     let(:text) { 'step text' }
     let(:location) { double }
 
@@ -10,7 +11,7 @@ module Cucumber::Core::Test
       it "describes itself to a visitor" do
         visitor = double
         args = double
-        test_step = Step.new(text, location)
+        test_step = Step.new(id, text, location)
         expect( visitor ).to receive(:test_step).with(test_step, args)
         test_step.describe_to(visitor, args)
       end
@@ -19,7 +20,7 @@ module Cucumber::Core::Test
     describe "backtrace line" do
       let(:text) { 'this step passes' }
       let(:location)  { Location.new('path/file.feature', 10) }
-      let(:test_step) { Step.new(text, location) }
+      let(:test_step) { Step.new(id, text, location) }
 
       it "knows how to form the backtrace line" do
         expect( test_step.backtrace_line ).to eq("path/file.feature:10:in `this step passes'")
@@ -30,7 +31,7 @@ module Cucumber::Core::Test
       it "passes arbitrary arguments to the action's block" do
         args_spy = nil
         expected_args = [double, double]
-        test_step = Step.new(text, location).with_action do |*actual_args|
+        test_step = Step.new(id, text, location).with_action do |*actual_args|
           args_spy = actual_args
         end
         test_step.execute(*expected_args)
@@ -39,7 +40,7 @@ module Cucumber::Core::Test
 
       context "when a passing action exists" do
         it "returns a passing result" do
-          test_step = Step.new(text, location).with_action {}
+          test_step = Step.new(id, text, location).with_action {}
           expect( test_step.execute ).to be_passed
         end
       end
@@ -48,7 +49,7 @@ module Cucumber::Core::Test
         let(:exception) { StandardError.new('oops') }
 
         it "returns a failing result" do
-          test_step = Step.new(text, location).with_action { raise exception }
+          test_step = Step.new(id, text, location).with_action { raise exception }
           result = test_step.execute
           expect( result           ).to be_failed
           expect( result.exception ).to eq exception
@@ -57,7 +58,7 @@ module Cucumber::Core::Test
 
       context "with no action" do
         it "returns an Undefined result" do
-          test_step = Step.new(text, location)
+          test_step = Step.new(id, text, location)
           result = test_step.execute
           expect( result           ).to be_undefined
         end
@@ -65,7 +66,7 @@ module Cucumber::Core::Test
     end
 
     it "exposes the text and location of as attributes" do
-      test_step = Step.new(text, location)
+      test_step = Step.new(id, text, location)
       expect( test_step.text              ).to eq text
       expect( test_step.location          ).to eq location
     end
@@ -73,13 +74,13 @@ module Cucumber::Core::Test
     it "exposes the location of the action as attribute" do
       location = double
       action = double(location: location)
-      test_step = Step.new(text, location, action)
+      test_step = Step.new(id, text, location, action)
       expect( test_step.action_location ).to eq location
     end
 
     it "returns the text when converted to a string" do
       text = 'a passing step'
-      test_step = Step.new(text, location)
+      test_step = Step.new(id, text, location)
       expect( test_step.to_s     ).to eq 'a passing step'
     end
 

--- a/spec/cucumber/core_spec.rb
+++ b/spec/cucumber/core_spec.rb
@@ -170,7 +170,7 @@ module Cucumber
       context "with around hooks" do
         class WithAroundHooks < Core::Filter.new(:logger)
           def test_case(test_case)
-            base_step = Core::Test::Step.new('text', nil, nil, nil)
+            base_step = Core::Test::Step.new('some-random-uid', 'text', nil, nil, nil)
             test_steps = [
               base_step.with_action { logger << :step },
             ]


### PR DESCRIPTION
## Summary

The idea is to take advantage of the event bus to easily manage relationships between `Test::Case` and `Pickles`, `Test::Step` and `PickleStep` (and later on `Test::Step` and `Hook` or `StepDefinition`)

All this of course in order to be able to produce the messages.

This code is not meant to be merged as it (no tests and it's quick & dirty) but more to discuss the approach itself.

In order for this to work, I also added a few tweaks in `cucumber-ruby`:
 - declare the new events in the Event bus
 - add the reporter
See here: https://github.com/cucumber/cucumber-ruby/commit/1288403bba3c80d838f2376ce375e3a4903dcf69

I'm not familiar enough with the event bus to ensure this is the proper solution. Any other input is welcome :) 

Note: some commits come from the PR about adding ids to the test case and step.