### PR TITLE
Remove unintended `private` call

### DIFF
--- a/lib/cucumber/core/test/result.rb
+++ b/lib/cucumber/core/test/result.rb
@@ -9,7 +9,6 @@ module Cucumber
         STRICT_AFFECTED_TYPES = [:flaky, :undefined, :pending].freeze
 
         def self.ok?(type, be_strict = StrictConfiguration.new)
-          private
           class_name = type.to_s.slice(0, 1).capitalize + type.to_s.slice(1..-1)
           const_get(class_name).ok?(be_strict.strict?(type))
         end


### PR DESCRIPTION
## Summary

This PR fixes the following warning:

```
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/cucumber-core-3.2.1/lib/cucumber/core/test/result.rb:12: warning: calling private without arguments inside a method may not have the intended effect
```

## Details

From reading https://bugs.ruby-lang.org/issues/13249, I don't think `private` is having any effect here, since it's only supposed to affect further methods defined inside the current class method (if at all), and this method does not define any method inside itself.

## Motivation and Context

Avoid warnings.

## How Has This Been Tested?

I think making sure that this doesn't break anything on currently tested rubies is enough. I haven't tried it in ruby 2.7, but since the method call is being removed, it's impossible that the warning won't be fixed :)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
