### PR TITLE
Add envelope event and emit it after parsing gherkin documents

### DIFF
--- a/lib/cucumber/core/events.rb
+++ b/lib/cucumber/core/events.rb
@@ -5,6 +5,10 @@ module Cucumber
   module Core
     module Events
 
+      class Envelope < Event.new(:envelope)
+        attr_reader :envelope
+      end
+
       # Signals that a gherkin source has been parsed
       class GherkinSourceParsed < Event.new(:gherkin_document)
         # @return [GherkinDocument] the GherkinDocument Ast Node
@@ -55,6 +59,7 @@ module Cucumber
       # that will be used by the {EventBus} by default.
       def self.registry
         build_registry(
+          Envelope,
           GherkinSourceParsed,
           TestCaseStarted,
           TestStepStarted,

--- a/lib/cucumber/core/gherkin/parser.rb
+++ b/lib/cucumber/core/gherkin/parser.rb
@@ -19,6 +19,7 @@ module Cucumber
         def document(document)
           messages = ::Gherkin.from_source(document.uri, document.body, gherkin_options(document))
           messages.each do |message|
+            event_bus.envelope(message)
             gherkin_query.update(message)
             if !message.gherkin_document.nil?
               event_bus.gherkin_source_parsed(message.gherkin_document)

--- a/spec/cucumber/core/gherkin/parser_spec.rb
+++ b/spec/cucumber/core/gherkin/parser_spec.rb
@@ -43,6 +43,12 @@ module Cucumber
             expect( event_bus ).to receive(:gherkin_source_parsed)
             parse
           end
+
+          it "emits an 'envelope' event for every message produced by Gherkin" do
+            # Only one message emited, there's no pickles generated
+            expect( event_bus ).to receive(:envelope).once
+            parse
+          end
         end
 
         context "for empty files" do
@@ -88,6 +94,13 @@ module Cucumber
 
           it "passes on the pickle" do
             expect( receiver ).to receive(:pickle)
+            parse
+          end
+
+          it "emits an 'envelope' event containing the pickle" do
+            allow( receiver ).to receive(:pickle)
+            # Once for the gherkin document, once with the pickle
+            expect( event_bus ).to receive(:envelope).twice
             parse
           end
         end

--- a/spec/cucumber/core/gherkin/parser_spec.rb
+++ b/spec/cucumber/core/gherkin/parser_spec.rb
@@ -15,6 +15,7 @@ module Cucumber
 
         before do
           allow( event_bus ).to receive(:gherkin_source_parsed)
+          allow( event_bus).to receive(:envelope)
           allow( gherkin_query ).to receive(:update)
         end
 


### PR DESCRIPTION
## Summary

A new `envelope` event is emitted in the `eventBus`, which should be emitted with every `cucumber-messages`.

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
