### PR TITLE
Use IdGenerator::UUID

### DIFF
--- a/lib/cucumber/core.rb
+++ b/lib/cucumber/core.rb
@@ -10,25 +10,25 @@ require 'gherkin/query'
 module Cucumber
   module Core
 
-    def execute(gherkin_documents, filters = [], event_bus = EventBus.new, id_generator = Cucumber::Messages::IdGenerator::Incrementing.new)
+    def execute(gherkin_documents, filters = [], event_bus = EventBus.new)
       yield event_bus if block_given?
       receiver = Test::Runner.new(event_bus)
-      compile gherkin_documents, receiver, filters, event_bus, id_generator
+      compile gherkin_documents, receiver, filters, event_bus
       self
     end
 
-    def compile(gherkin_documents, last_receiver, filters = [], event_bus = EventBus.new, id_generator = Cucumber::Messages::IdGenerator::Incrementing.new)
+    def compile(gherkin_documents, last_receiver, filters = [], event_bus = EventBus.new)
       first_receiver = compose(filters, last_receiver)
       gherkin_query = ::Gherkin::Query.new
-      compiler = Compiler.new(first_receiver, gherkin_query, id_generator, event_bus)
-      parse gherkin_documents, compiler, event_bus, gherkin_query, id_generator
+      compiler = Compiler.new(first_receiver, gherkin_query, event_bus)
+      parse gherkin_documents, compiler, event_bus, gherkin_query
       self
     end
 
     private
 
-    def parse(gherkin_documents, compiler, event_bus, gherkin_query, id_generator)
-      parser = Core::Gherkin::Parser.new(compiler, event_bus, gherkin_query, id_generator)
+    def parse(gherkin_documents, compiler, event_bus, gherkin_query)
+      parser = Core::Gherkin::Parser.new(compiler, event_bus, gherkin_query)
       gherkin_documents.each do |document|
         parser.document document
       end
@@ -41,6 +41,5 @@ module Cucumber
         filter.with_receiver(receiver)
       end
     end
-
   end
 end

--- a/lib/cucumber/core/compiler.rb
+++ b/lib/cucumber/core/compiler.rb
@@ -6,6 +6,7 @@ require 'cucumber/core/test/tag'
 require 'cucumber/core/test/doc_string'
 require 'cucumber/core/test/data_table'
 require 'cucumber/core/test/empty_multiline_argument'
+require 'cucumber/messages'
 
 module Cucumber
   module Core
@@ -14,9 +15,9 @@ module Cucumber
       attr_reader :receiver, :gherkin_query, :id_generator
       private     :receiver, :gherkin_query, :id_generator
 
-      def initialize(receiver, gherkin_query, id_generator, event_bus = nil)
+      def initialize(receiver, gherkin_query, event_bus = nil)
         @receiver = receiver
-        @id_generator = id_generator
+        @id_generator = Cucumber::Messages::IdGenerator::UUID.new
         @gherkin_query = gherkin_query
         @event_bus = event_bus
       end

--- a/lib/cucumber/core/gherkin/parser.rb
+++ b/lib/cucumber/core/gherkin/parser.rb
@@ -7,14 +7,13 @@ module Cucumber
       ParseError = Class.new(StandardError)
 
       class Parser
-        attr_reader :receiver, :event_bus, :gherkin_query, :id_generator
-        private     :receiver, :event_bus, :gherkin_query, :id_generator
+        attr_reader :receiver, :event_bus, :gherkin_query
+        private     :receiver, :event_bus, :gherkin_query
 
-        def initialize(receiver, event_bus, gherkin_query, id_generator)
+        def initialize(receiver, event_bus, gherkin_query)
           @receiver = receiver
           @event_bus = event_bus
           @gherkin_query = gherkin_query
-          @id_generator = id_generator
         end
 
         def document(document)
@@ -40,8 +39,7 @@ module Cucumber
             default_dialect: document.language,
             include_source: false,
             include_gherkin_document: true,
-            include_pickles: true,
-            id_generator: id_generator
+            include_pickles: true
           }
         end
 

--- a/spec/cucumber/core/gherkin/parser_spec.rb
+++ b/spec/cucumber/core/gherkin/parser_spec.rb
@@ -10,15 +10,13 @@ module Cucumber
         let(:receiver)  { double }
         let(:event_bus) { double }
         let(:gherkin_query) { double }
-        let(:id_generator) { double }
-        let(:parser)    { Parser.new(receiver, event_bus, gherkin_query, id_generator) }
+        let(:parser)    { Parser.new(receiver, event_bus, gherkin_query) }
         let(:visitor)   { double }
 
         before do
           allow( event_bus ).to receive(:gherkin_source_parsed)
           allow( event_bus).to receive(:envelope)
           allow( gherkin_query ).to receive(:update)
-          allow( id_generator ).to receive(:new_id)
         end
 
         def parse


### PR DESCRIPTION
## Summary

Original idea behind CCK was to have predictable ids for comparing messages, but the way we compare messages in CCK (using `json-formatter`) makes this useless finally.