### PR TITLE
Bump Gherkin, messsages and tag-expressions to latest releases

### DIFF
--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |s|
                     'source_code_uri' => 'https://github.com/cucumber/cucumber-ruby-core',
                   }
 
-  s.add_dependency 'cucumber-gherkin', '~> 10.0', '>= 10.0.0'
-  s.add_dependency 'cucumber-messages', '~> 10.0', '>= 10.0.1'
-  s.add_dependency 'cucumber-tag_expressions', '~> 2.0', '>= 2.0.2'
+  s.add_dependency 'cucumber-gherkin', '~> 12.0', '>= 12.0.0'
+  s.add_dependency 'cucumber-messages', '~> 11.1', '>= 11.1.1'
+  s.add_dependency 'cucumber-tag-expressions', '~> 2.0', '>= 2.0.4'
 
   s.add_development_dependency 'coveralls', '~> 0.8', '>= 0.8.23'
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.0'

--- a/lib/cucumber/core/gherkin/parser.rb
+++ b/lib/cucumber/core/gherkin/parser.rb
@@ -27,7 +27,7 @@ module Cucumber
               receiver.pickle(message.pickle)
             elsif !message.attachment.nil?
               # Parse error
-              raise Core::Gherkin::ParseError.new("#{document.uri}: #{message.attachment.text}")
+              raise Core::Gherkin::ParseError.new("#{document.uri}: #{message.attachment.body}")
             else
               raise "Unknown message: #{message.to_hash}"
             end


### PR DESCRIPTION
Follow up on new releases in the mono-repo.

This should also allow `cucumber-ruby` to validate against CCK.