### PR TITLE
Update gherkin and messages (2020/7/30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Changed
 
-  * N/A
+* Updated gems:
+  * `cucumber-gherkin` ~> 14.1.0
+  * `cucumber-messages` ~> 12.3.2
 
 ### Removed
 

--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
                     'source_code_uri' => 'https://github.com/cucumber/cucumber-ruby-core',
                   }
 
-  s.add_dependency 'cucumber-gherkin', '~> 14.0', '>= 14.0.1'
-  s.add_dependency 'cucumber-messages', '~> 12.2', '>= 12.2.0'
+  s.add_dependency 'cucumber-gherkin', '~> 14.1', '>= 14.1.0'
+  s.add_dependency 'cucumber-messages', '~> 12.3', '>= 12.3.2'
   s.add_dependency 'cucumber-tag-expressions', '~> 2.0', '>= 2.0.4'
 
   s.add_development_dependency 'coveralls', '~> 0.8', '>= 0.8.23'


### PR DESCRIPTION
Follow-up of the releases done today on the mono-repo:
 - gherkin 14.1.0
 - message 12.3.2
