### PR TITLE
Fix .rubocop.yml & add dependency on RuboCop::Packaging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,8 +32,8 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   CountComments: false
   Exclude:
-    - './cucumber.gemspec'
-    - './spec/**/*'
+    - 'cucumber-core.gemspec'
+    - 'spec/**/*'
 
 Metrics/ClassLength:
   Max: 375
@@ -49,7 +49,7 @@ Layout/LineLength:
 Metrics/ModuleLength:
   Max: 150
   Exclude:
-    - './spec/**/*'
+    - 'spec/**/*'
 
 Metrics/MethodLength:
   Max: 30

--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.1'
   s.add_development_dependency 'rspec', '~> 3.9', '>= 3.9.0'
   s.add_development_dependency 'rubocop', '~> 0.89', '>= 0.89.1'
+  s.add_development_dependency 'rubocop-packaging', '~> 0.3', '>= 0.3.0'
   s.add_development_dependency 'unindent', '~> 1.0', '>= 1.0'
 
   s.rubygems_version = ">= 1.6.1"


### PR DESCRIPTION
Hi,

This fixes (very minorly) the `.rubocop.yml` file and adds a dependency on `rubocop-packaging` so that it's easier for downstream (Debian) to maintain this! ❤️ 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>