### PR TITLE
Bump RuboCop::Packaging to v0.5

### DIFF
--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.1'
   s.add_development_dependency 'rspec', '~> 3.9', '>= 3.9.0'
   s.add_development_dependency 'rubocop', '~> 0.89', '>= 0.89.1'
-  s.add_development_dependency 'rubocop-packaging', '~> 0.3', '>= 0.3.0'
+  s.add_development_dependency 'rubocop-packaging', '~> 0.5', '>= 0.5.1'
   s.add_development_dependency 'unindent', '~> 1.0', '>= 1.0'
 
   s.rubygems_version = ">= 1.6.1"


### PR DESCRIPTION
RuboCop::Packaging through v0.5 supports
autocorrect for its cops. Thus worth bumping
the version from v0.3 to v0.5.

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>
