### PR TITLE
Enable RuboCop::Packaging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 inherit_from: .rubocop_todo.yml
 
+require:
+  - rubocop-packaging
+
 AllCops:
   # Keep this inline with the lowest ruby-* version in circleci/config.yml and
   # the version in the gemspec

--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.1'
   s.add_development_dependency 'rspec', '~> 3.9', '>= 3.9.0'
   s.add_development_dependency 'rubocop', '~> 0.89', '>= 0.89.1'
-  s.add_development_dependency 'rubocop-packaging', '~> 0.3', '>= 0.3.0'
+  s.add_development_dependency 'rubocop-packaging', '~> 0.5', '>= 0.5.1'
   s.add_development_dependency 'unindent', '~> 1.0', '>= 1.0'
 
   s.rubygems_version = ">= 1.6.1"

--- a/spec/coverage.rb
+++ b/spec/coverage.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rubygems'
-require 'bundler/setup'
 require 'simplecov'
 formatters = [ SimpleCov::Formatter::HTMLFormatter ]
 


### PR DESCRIPTION
This PR enables RuboCop::Packaging and autocorrects
an issue by dropping `require 'bunder/setup` from `spec/`.

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>