### PR TITLE
Update cucumber-messages and cucumber-gherkin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Dependencies
 
+* Updated gems: `cucumber-gherkin` ~> 19.0.3 and `cucumber-messages` ~> 16.0.1
+
 ## [9.0.1](https://github.com/cucumber/cucumber-ruby-core/compare/v9.0.0...v9.0.1)
 
 ### Fixed

--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
                     'source_code_uri' => 'https://github.com/cucumber/cucumber-ruby-core',
                   }
 
-  s.add_dependency 'cucumber-gherkin', '~> 18.1', '>= 18.1.0'
-  s.add_dependency 'cucumber-messages', '~> 15.0', '>= 15.0.0'
+  s.add_dependency 'cucumber-gherkin', '~> 19.0', '>= 19.0.3'
+  s.add_dependency 'cucumber-messages', '~> 16.0', '>= 16.0.1'
   s.add_dependency 'cucumber-tag-expressions', '~> 3.0', '>= 3.0.1'
 
   s.add_development_dependency 'coveralls', '~> 0.8', '>= 0.8.23'


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

In order to update cucumber-html-reporter dependency in cucumber-ruby, we require an update of cucumber-messages dependency in cucumber-core

**Describe the solution you have implemented**
Update dependencies
