### PR TITLE
Release v10.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Dependencies
 
+## [10.1.0](https://github.com/cucumber/cucumber-ruby-core/compare/v10.0.1...v10.1.0)
+
+### Dependencies
+
+* Patched `cucumber-gherkin`, `cucumber-messages` and `cucumber-tag-expressions`
 
 ## [10.0.1](https://github.com/cucumber/cucumber-ruby-core/compare/v10.0.0...v10.0.1)
 

--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls', '~> 0.8', '>= 0.8.23'
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
   s.add_development_dependency 'rspec', '~> 3.10', '>= 3.10.0'
-  s.add_development_dependency 'rubocop', '~> 1.21', '>= 1.21.0'
+  s.add_development_dependency 'rubocop', '~> 1.22', '>= 1.22.1'
   s.add_development_dependency 'rubocop-packaging', '~> 0.5', '>= 0.5.1'
   s.add_development_dependency 'unindent', '~> 1.0', '>= 1.0'
 

--- a/lib/cucumber/core/version.rb
+++ b/lib/cucumber/core/version.rb
@@ -3,7 +3,7 @@ module Cucumber
   module Core
     class Version
       def self.to_s
-        "10.0.1"
+        "10.1.0"
       end
     end
   end


### PR DESCRIPTION
# Description

Once merge to `main`, then pushed to `release/10.1.0`, that would trigger a release.
That would be more likely to test the release workflow actually. If it is working fine, I would then add the same workflow to `cucumber-ruby-wire` and `cucumber-ruby`, then actually release `cucumber-ruby`.

note: the branch is 10.0.2 because at first I was about to release it as 10.0.2.