### PR TITLE
Restore support for matching a scenario by its tags' and steps' line numbers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Fixed
 
+* Restore support for matching a scenario by its tags' and steps' line numbers.
+
 ### Dependencies
 
 ## [11.0.0](https://github.com/cucumber/cucumber-ruby-core/compare/v10.1.1...v11.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Fixed
 
-* Restore support for matching a scenario by its tags' and steps' line numbers.
+* Restore support for matching a scenario by tag and step line numbers.
 
 ### Dependencies
 

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -53,8 +53,14 @@ module Cucumber
 
         def match_locations?(queried_locations)
           queried_locations.any? do |queried_location|
-            queried_location.match? location
+            matching_locations.any? do |location|
+              queried_location.match? location
+            end
           end
+        end
+
+        def matching_locations
+          [location] + test_steps.map(&:location)
         end
 
         def inspect

--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -60,7 +60,11 @@ module Cucumber
         end
 
         def matching_locations
-          [location] + test_steps.map(&:location)
+          [
+            location,
+            tags.map(&:location),
+            test_steps.map(&:location),
+          ].flatten
         end
 
         def inspect

--- a/lib/cucumber/core/test/filters/locations_filter.rb
+++ b/lib/cucumber/core/test/filters/locations_filter.rb
@@ -26,7 +26,7 @@ module Cucumber
         def sorted_test_cases
           filter_locations.map { |filter_location|
             test_cases[filter_location.file].select { |test_case|
-              filter_location.match?(test_case.location)
+              test_case.match_locations?([filter_location])
             }
           }.flatten.uniq
         end

--- a/spec/cucumber/core/test/filters/locations_filter_spec.rb
+++ b/spec/cucumber/core/test/filters/locations_filter_spec.rb
@@ -73,6 +73,8 @@ module Cucumber::Core
         let(:doc) do
           Gherkin::Document.new(file, <<-END)
             Feature:
+              Background:
+                Given background
 
               Scenario: one
                 Given one a
@@ -105,6 +107,13 @@ module Cucumber::Core
           test_cases.find { |c| c.name == name }
         end
 
+        it 'matches the location on a background step to all scenarios' do
+          location = Test::Location.new(file, 3)
+          filter = Test::LocationsFilter.new([location])
+          compile [doc], receiver, [filter]
+          expect(receiver.test_case_locations).to eq test_cases.map(&:location)
+        end
+
         it 'matches the precise location of the scenario' do
           location = test_case_named('two').location
           filter = Test::LocationsFilter.new([location])
@@ -113,36 +122,36 @@ module Cucumber::Core
         end
 
         it 'matches multiple locations' do
-          good_location = Test::Location.new(file, 8)
-          bad_location = Test::Location.new(file, 5)
+          good_location = Test::Location.new(file, 10)
+          bad_location = Test::Location.new(file, 7)
           filter = Test::LocationsFilter.new([good_location, bad_location])
           compile [doc], receiver, [filter]
           expect(receiver.test_case_locations).to eq [test_case_named('two').location]
         end
 
         it 'matches a location on the first step of the scenario' do
-          location = Test::Location.new(file, 9)
+          location = Test::Location.new(file, 11)
           filter = Test::LocationsFilter.new([location])
           compile [doc], receiver, [filter]
           expect(receiver.test_case_locations).to eq [test_case_named('two').location]
         end
 
         it 'matches a location on the last step of the scenario' do
-          location = Test::Location.new(file, 10)
+          location = Test::Location.new(file, 12)
           filter = Test::LocationsFilter.new([location])
           compile [doc], receiver, [filter]
           expect(receiver.test_case_locations).to eq [test_case_named('two').location]
         end
 
         it "matches a location on the scenario's tags" do
-          location = Test::Location.new(file, 7)
+          location = Test::Location.new(file, 9)
           filter = Test::LocationsFilter.new([location])
           compile [doc], receiver, [filter]
           expect(receiver.test_case_locations).to eq [test_case_named('two').location]
         end
 
         it "does not return a matched location on a whitespace line" do
-          location = Test::Location.new(file, 11)
+          location = Test::Location.new(file, 13)
           filter = Test::LocationsFilter.new([location])
           compile [doc], receiver, [filter]
           expect(receiver.test_case_locations).to eq []
@@ -152,7 +161,7 @@ module Cucumber::Core
           it "matches each test case only once" do
             location_tc_two = test_case_named('two').location
             location_tc_one = test_case_named('one').location
-            location_last_step_tc_two = Test::Location.new(file, 10)
+            location_last_step_tc_two = Test::Location.new(file, 12)
             filter = Test::LocationsFilter.new([location_tc_two, location_tc_one, location_last_step_tc_two])
             compile [doc], receiver, [filter]
             expect(receiver.test_case_locations).to eq [test_case_named('two').location, location_tc_one = test_case_named('one').location]

--- a/spec/cucumber/core/test/filters/locations_filter_spec.rb
+++ b/spec/cucumber/core/test/filters/locations_filter_spec.rb
@@ -141,7 +141,7 @@ module Cucumber::Core
           expect(receiver.test_case_locations).to eq [test_case_named('two').location]
         end
 
-        xit "matches a location on the scenario's tags" do
+        it "matches a location on the scenario's tags" do
           location = Test::Location.new(file, 7)
           filter = Test::LocationsFilter.new([location])
           compile [doc], receiver, [filter]
@@ -284,7 +284,7 @@ module Cucumber::Core
           expect(receiver.test_case_locations.map(&:line)).to eq [19, 23, 24]
         end
 
-        xit "matches a location on the scenario outline's tags with all test cases of all the tables" do
+        it "matches a location on the scenario outline's tags with all test cases of all the tables" do
           location = Test::Location.new(file, 7)
           filter = Test::LocationsFilter.new([location])
           compile [doc], receiver, [filter]

--- a/spec/cucumber/core/test/filters/locations_filter_spec.rb
+++ b/spec/cucumber/core/test/filters/locations_filter_spec.rb
@@ -120,18 +120,91 @@ module Cucumber::Core
           expect(receiver.test_case_locations).to eq [test_case_named('two').location]
         end
 
-        it "doesn't match a location after the scenario line" do
+        it "matches the location of a step of the scenario" do
           location = Test::Location.new(file, 9)
+          filter = Test::LocationsFilter.new([location])
+          compile [doc], receiver, [filter]
+          expect(receiver.test_case_locations).to eq [test_case_named('two').location]
+        end
+
+        it 'matches a location on the last step of the scenario' do
+          location = Test::Location.new(file, 10)
+          filter = Test::LocationsFilter.new([location])
+          compile [doc], receiver, [filter]
+          expect(receiver.test_case_locations).to eq [test_case_named('two').location]
+        end
+
+        xit "matches a location on the scenario's comment" do
+          location = Test::Location.new(file, 6)
+          filter = Test::LocationsFilter.new([location])
+          compile [doc], receiver, [filter]
+          expect(receiver.test_case_locations).to eq [test_case_named('two').location]
+        end
+
+        xit "matches a location on the scenario's tags" do
+          location = Test::Location.new(file, 7)
+          filter = Test::LocationsFilter.new([location])
+          compile [doc], receiver, [filter]
+          expect(receiver.test_case_locations).to eq [test_case_named('two').location]
+        end
+
+        it "doesn't match a location after the last step of the scenario" do
+          location = Test::Location.new(file, 11)
           filter = Test::LocationsFilter.new([location])
           compile [doc], receiver, [filter]
           expect(receiver.test_case_locations).to eq []
         end
 
-        it "doesn't match a location before the scenario line" do
-          location = Test::Location.new(file, 7)
+        it "doesn't match a location before the scenario" do
+          location = Test::Location.new(file, 5)
           filter = Test::LocationsFilter.new([location])
           compile [doc], receiver, [filter]
           expect(receiver.test_case_locations).to eq []
+        end
+
+        context "with a docstring" do
+          let(:test_case) do
+            test_cases.find { |c| c.name == 'with docstring' }
+          end
+
+          xit "matches a location at the start the docstring" do
+            location = Test::Location.new(file, 17)
+            filter = Test::LocationsFilter.new([location])
+            compile [doc], receiver, [filter]
+            expect(receiver.test_case_locations).to eq [test_case_named('with docstring').location]
+          end
+
+          xit "matches a location in the middle of the docstring" do
+            location = Test::Location.new(file, 18)
+            filter = Test::LocationsFilter.new([location])
+            compile [doc], receiver, [filter]
+            expect(receiver.test_case_locations).to eq [test_case_named('with docstring').location]
+          end
+
+          xit "matches a location at the end of the docstring" do
+            location = Test::Location.new(file, 19)
+            filter = Test::LocationsFilter.new([location])
+            compile [doc], receiver, [filter]
+            expect(receiver.test_case_locations).to eq [test_case_named('with docstring').location]
+          end
+
+          it "does not match a location after the docstring" do
+            location = Test::Location.new(file, 20)
+            expect(test_case.match_locations?([location])).to be_falsy
+          end
+        end
+
+        context "with a table" do
+          let(:test_case) do
+            test_cases.find { |c| c.name == 'with a table' }
+          end
+
+          xit "matches a location on the first table row" do
+            location = Test::Location.new(file, 23)
+            filter = Test::LocationsFilter.new([location])
+            compile [doc], receiver, [filter]
+            expect(receiver.test_case_locations).to eq [test_case_named('with a table').location]
+          end
         end
 
         context "with duplicate locations in the filter" do
@@ -184,21 +257,52 @@ module Cucumber::Core
         end
 
         it "matches row location to the test case of the row" do
-          locations = [
-            Test::Location.new(file, 19),
-          ]
-          filter = Test::LocationsFilter.new(locations)
+          location = Test::Location.new(file, 19)
+          filter = Test::LocationsFilter.new([location])
           compile [doc], receiver, [filter]
           expect(receiver.test_case_locations).to eq [test_case.location]
         end
 
         it "matches outline location with the all test cases of all the tables" do
-          locations = [
-            Test::Location.new(file, 8),
-          ]
-          filter = Test::LocationsFilter.new(locations)
+          location = Test::Location.new(file, 8)
+          filter = Test::LocationsFilter.new([location])
           compile [doc], receiver, [filter]
           expect(receiver.test_case_locations.map(&:line)).to eq [19, 23, 24]
+        end
+
+        it "matches a location on a step of the scenario outline with all test cases of all the tables" do
+          location = Test::Location.new(file, 10)
+          filter = Test::LocationsFilter.new([location])
+          compile [doc], receiver, [filter]
+          expect(receiver.test_case_locations.map(&:line)).to eq [19, 23, 24]
+        end
+
+        xit "matches a location on the scenario outline's comment with all test cases of all the tables" do
+          location = Test::Location.new(file, 6)
+          filter = Test::LocationsFilter.new([location])
+          compile [doc], receiver, [filter]
+          expect(receiver.test_case_locations.map(&:line)).to eq [19, 23, 24]
+        end
+
+        xit "matches a location on the scenario outline's tags with all test cases of all the tables" do
+          location = Test::Location.new(file, 7)
+          filter = Test::LocationsFilter.new([location])
+          compile [doc], receiver, [filter]
+          expect(receiver.test_case_locations.map(&:line)).to eq [19, 23, 24]
+        end
+
+        it "doesn't match a location after the last row of the examples table" do
+          location = Test::Location.new(file, 20)
+          filter = Test::LocationsFilter.new([location])
+          compile [doc], receiver, [filter]
+          expect(receiver.test_case_locations).to eq []
+        end
+
+        it "doesn't match a location before the scenario outline" do
+          location = Test::Location.new(file, 5)
+          filter = Test::LocationsFilter.new([location])
+          compile [doc], receiver, [filter]
+          expect(receiver.test_case_locations).to eq []
         end
 
         it "doesn't match the location of the examples line" do

--- a/spec/cucumber/core/test/filters/locations_filter_spec.rb
+++ b/spec/cucumber/core/test/filters/locations_filter_spec.rb
@@ -120,7 +120,7 @@ module Cucumber::Core
           expect(receiver.test_case_locations).to eq [test_case_named('two').location]
         end
 
-        it "matches the location of a step of the scenario" do
+        it 'matches a location on the first step of the scenario' do
           location = Test::Location.new(file, 9)
           filter = Test::LocationsFilter.new([location])
           compile [doc], receiver, [filter]
@@ -134,13 +134,6 @@ module Cucumber::Core
           expect(receiver.test_case_locations).to eq [test_case_named('two').location]
         end
 
-        xit "matches a location on the scenario's comment" do
-          location = Test::Location.new(file, 6)
-          filter = Test::LocationsFilter.new([location])
-          compile [doc], receiver, [filter]
-          expect(receiver.test_case_locations).to eq [test_case_named('two').location]
-        end
-
         it "matches a location on the scenario's tags" do
           location = Test::Location.new(file, 7)
           filter = Test::LocationsFilter.new([location])
@@ -148,63 +141,11 @@ module Cucumber::Core
           expect(receiver.test_case_locations).to eq [test_case_named('two').location]
         end
 
-        it "doesn't match a location after the last step of the scenario" do
+        it "does not return a matched location on a whitespace line" do
           location = Test::Location.new(file, 11)
           filter = Test::LocationsFilter.new([location])
           compile [doc], receiver, [filter]
           expect(receiver.test_case_locations).to eq []
-        end
-
-        it "doesn't match a location before the scenario" do
-          location = Test::Location.new(file, 5)
-          filter = Test::LocationsFilter.new([location])
-          compile [doc], receiver, [filter]
-          expect(receiver.test_case_locations).to eq []
-        end
-
-        context "with a docstring" do
-          let(:test_case) do
-            test_cases.find { |c| c.name == 'with docstring' }
-          end
-
-          xit "matches a location at the start the docstring" do
-            location = Test::Location.new(file, 17)
-            filter = Test::LocationsFilter.new([location])
-            compile [doc], receiver, [filter]
-            expect(receiver.test_case_locations).to eq [test_case_named('with docstring').location]
-          end
-
-          xit "matches a location in the middle of the docstring" do
-            location = Test::Location.new(file, 18)
-            filter = Test::LocationsFilter.new([location])
-            compile [doc], receiver, [filter]
-            expect(receiver.test_case_locations).to eq [test_case_named('with docstring').location]
-          end
-
-          xit "matches a location at the end of the docstring" do
-            location = Test::Location.new(file, 19)
-            filter = Test::LocationsFilter.new([location])
-            compile [doc], receiver, [filter]
-            expect(receiver.test_case_locations).to eq [test_case_named('with docstring').location]
-          end
-
-          it "does not match a location after the docstring" do
-            location = Test::Location.new(file, 20)
-            expect(test_case.match_locations?([location])).to be_falsy
-          end
-        end
-
-        context "with a table" do
-          let(:test_case) do
-            test_cases.find { |c| c.name == 'with a table' }
-          end
-
-          xit "matches a location on the first table row" do
-            location = Test::Location.new(file, 23)
-            filter = Test::LocationsFilter.new([location])
-            compile [doc], receiver, [filter]
-            expect(receiver.test_case_locations).to eq [test_case_named('with a table').location]
-          end
         end
 
         context "with duplicate locations in the filter" do
@@ -277,32 +218,11 @@ module Cucumber::Core
           expect(receiver.test_case_locations.map(&:line)).to eq [19, 23, 24]
         end
 
-        xit "matches a location on the scenario outline's comment with all test cases of all the tables" do
-          location = Test::Location.new(file, 6)
-          filter = Test::LocationsFilter.new([location])
-          compile [doc], receiver, [filter]
-          expect(receiver.test_case_locations.map(&:line)).to eq [19, 23, 24]
-        end
-
         it "matches a location on the scenario outline's tags with all test cases of all the tables" do
           location = Test::Location.new(file, 7)
           filter = Test::LocationsFilter.new([location])
           compile [doc], receiver, [filter]
           expect(receiver.test_case_locations.map(&:line)).to eq [19, 23, 24]
-        end
-
-        it "doesn't match a location after the last row of the examples table" do
-          location = Test::Location.new(file, 20)
-          filter = Test::LocationsFilter.new([location])
-          compile [doc], receiver, [filter]
-          expect(receiver.test_case_locations).to eq []
-        end
-
-        it "doesn't match a location before the scenario outline" do
-          location = Test::Location.new(file, 5)
-          filter = Test::LocationsFilter.new([location])
-          compile [doc], receiver, [filter]
-          expect(receiver.test_case_locations).to eq []
         end
 
         it "doesn't match the location of the examples line" do


### PR DESCRIPTION
# Description
The Cucumber 4.0 release introduced some regressions in matching scenarios by line numbers other than the exact scenario line. The feature line, tag line, background lines, and step lines all stopped matching their related scenario(s). More context at https://github.com/cucumber/cucumber-ruby/issues/1469

This PR is the first step towards restoring that functionality, and only restores the tags and step lines being matched. It also restores the old tests that used to cover all the matching functionality, pending the ones that still need implementation work.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] RDoc comments have been updated
- [x] CHANGELOG.md has been updated