### PR TITLE
Restore support for matching a scenario by multiline step argument line numbers

### DIFF
--- a/lib/cucumber/core/test/case.rb
+++ b/lib/cucumber/core/test/case.rb
@@ -63,7 +63,7 @@ module Cucumber
           [
             location,
             tags.map(&:location),
-            test_steps.map(&:location),
+            test_steps.map(&:matching_locations)
           ].flatten
         end
 

--- a/lib/cucumber/core/test/data_table.rb
+++ b/lib/cucumber/core/test/data_table.rb
@@ -80,6 +80,10 @@ module Cucumber
           self.class.new(new_raw)
         end
 
+        def lines_count
+          raw.count
+        end
+
         def ==(other)
           other.class == self.class && raw == other.raw
         end

--- a/lib/cucumber/core/test/doc_string.rb
+++ b/lib/cucumber/core/test/doc_string.rb
@@ -50,6 +50,10 @@ module Cucumber
           self
         end
 
+        def lines_count
+          lines.count + 2
+        end
+
         def ==(other)
           if other.respond_to?(:content_type)
             return false unless content_type == other.content_type
@@ -68,7 +72,6 @@ module Cucumber
             %{  """>}
           ].join("\n")
         end
-
       end
     end
   end

--- a/lib/cucumber/core/test/empty_multiline_argument.rb
+++ b/lib/cucumber/core/test/empty_multiline_argument.rb
@@ -19,8 +19,8 @@ module Cucumber
           self
         end
 
-        def all_locations
-          []
+        def lines_count
+          0
         end
 
         def inspect

--- a/lib/cucumber/core/test/location.rb
+++ b/lib/cucumber/core/test/location.rb
@@ -79,8 +79,8 @@ module Cucumber
             to_s
           end
 
-          def select_down(lines_count)
-            new_lines = (0..lines_count).map do |offset|
+          def merge(multiline_arg)
+            new_lines = (0..multiline_arg.lines_count).map do |offset|
               lines.min + offset
             end
             Location.new(file, new_lines)

--- a/lib/cucumber/core/test/location.rb
+++ b/lib/cucumber/core/test/location.rb
@@ -79,6 +79,13 @@ module Cucumber
             to_s
           end
 
+          def select_down(lines_count)
+            new_lines = (0..lines_count).map do |offset|
+              lines.min + offset
+            end
+            Location.new(file, new_lines)
+          end
+
           def on_line(new_line)
             Location.new(file, new_line)
           end

--- a/lib/cucumber/core/test/step.rb
+++ b/lib/cucumber/core/test/step.rb
@@ -52,11 +52,7 @@ module Cucumber
         end
 
         def matching_locations
-          if multiline_arg
-            [location.select_down(multiline_arg.lines_count)]
-          else
-            [location]
-          end
+          [location.merge(multiline_arg)]
         end
 
         def inspect

--- a/lib/cucumber/core/test/step.rb
+++ b/lib/cucumber/core/test/step.rb
@@ -51,6 +51,23 @@ module Cucumber
           @action.location
         end
 
+        def matching_locations
+          case multiline_arg
+          when DocString, DataTable
+            length = begin
+              multiline_arg.lines.count + 2
+            rescue NoMethodError
+              multiline_arg.raw.count
+            end
+            lines = (1..length).map do |offset|
+              location.lines.min + offset
+            end
+            [location, Location.new(location.file, lines)]
+          else
+            [location]
+          end
+        end
+
         def inspect
           "#<#{self.class}: #{location}>"
         end

--- a/lib/cucumber/core/test/step.rb
+++ b/lib/cucumber/core/test/step.rb
@@ -52,17 +52,8 @@ module Cucumber
         end
 
         def matching_locations
-          case multiline_arg
-          when DocString, DataTable
-            length = begin
-              multiline_arg.lines.count + 2
-            rescue NoMethodError
-              multiline_arg.raw.count
-            end
-            lines = (1..length).map do |offset|
-              location.lines.min + offset
-            end
-            [location, Location.new(location.file, lines)]
+          if multiline_arg
+            [location.select_down(multiline_arg.lines_count)]
           else
             [location]
           end

--- a/spec/cucumber/core/test/filters/locations_filter_spec.rb
+++ b/spec/cucumber/core/test/filters/locations_filter_spec.rb
@@ -157,6 +157,60 @@ module Cucumber::Core
           expect(receiver.test_case_locations).to eq []
         end
 
+        context "with a docstring" do
+          let(:test_case) do
+            test_cases.find { |c| c.name == 'with docstring' }
+          end
+
+          it "matches a location at the start the docstring" do
+            location = Test::Location.new(file, 17)
+            filter = Test::LocationsFilter.new([location])
+            compile [doc], receiver, [filter]
+            expect(receiver.test_case_locations).to eq [test_case_named('with docstring').location]
+          end
+
+          it "matches a location in the middle of the docstring" do
+            location = Test::Location.new(file, 18)
+            filter = Test::LocationsFilter.new([location])
+            compile [doc], receiver, [filter]
+            expect(receiver.test_case_locations).to eq [test_case_named('with docstring').location]
+          end
+
+          it "matches a location at the end of the docstring" do
+            location = Test::Location.new(file, 19)
+            filter = Test::LocationsFilter.new([location])
+            compile [doc], receiver, [filter]
+            expect(receiver.test_case_locations).to eq [test_case_named('with docstring').location]
+          end
+        end
+
+        context "with a table" do
+          let(:test_case) do
+            test_cases.find { |c| c.name == 'with a table' }
+          end
+
+          it "matches a location at the start of the table" do
+            location = Test::Location.new(file, 23)
+            filter = Test::LocationsFilter.new([location])
+            compile [doc], receiver, [filter]
+            expect(receiver.test_case_locations).to eq [test_case_named('with a table').location]
+          end
+
+          it "matches a location at the middle of the table" do
+            location = Test::Location.new(file, 24)
+            filter = Test::LocationsFilter.new([location])
+            compile [doc], receiver, [filter]
+            expect(receiver.test_case_locations).to eq [test_case_named('with a table').location]
+          end
+
+          it "matches a location at the end of the table" do
+            location = Test::Location.new(file, 25)
+            filter = Test::LocationsFilter.new([location])
+            compile [doc], receiver, [filter]
+            expect(receiver.test_case_locations).to eq [test_case_named('with a table').location]
+          end
+        end
+
         context "with duplicate locations in the filter" do
           it "matches each test case only once" do
             location_tc_two = test_case_named('two').location


### PR DESCRIPTION
# Description
The Cucumber 4.0 release introduced some regressions in matching scenarios by line numbers other than the exact scenario line. The feature line, tag line, background lines, and step lines all stopped matching their related scenario(s). More context at https://github.com/cucumber/cucumber-ruby/issues/1469

This PR builds on top of https://github.com/cucumber/cucumber-ruby-core/pull/238 to also match multiline arguments like tables and docstrings. Note that I didn't update the CHANGELOG because I think this falls within the changelog line added in the previous PR.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] Tests have been added for any changes to behaviour of the code
- [x] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [x] RDoc comments have been updated
- [x] CHANGELOG.md has been updated