### PR TITLE
Use jruby-head for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
             bundler: '2.3.17'
             rubygems: '3.2.3'
           - os: ubuntu-latest
-            ruby: jruby
+            ruby: jruby-head
           - os: macos-latest
             ruby: '3.2'
           - os: windows-latest

--- a/spec/cucumber/core_spec.rb
+++ b/spec/cucumber/core_spec.rb
@@ -99,8 +99,6 @@ describe Cucumber::Core do
     end
 
     it 'fires events' do
-      pending 'This spec fails in JRuby. See https://github.com/jruby/jruby/issues/7988, for details' if defined?(JRUBY_VERSION)
-
       observed_events = []
       execute [gherkin_document], [Cucumber::Core::Test::Filters::ActivateStepsForSelfTest.new] do |event_bus|
         event_bus.on(:test_case_started) do |event|


### PR DESCRIPTION
# Description

Testing JRuby master (9.4.5.0-SNAPSHOT) to ensure that https://github.com/jruby/jruby/issues/7988 is fixed.

## Type of change

- Testing change to use jruby-head instead of latest release

# Checklist:

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
