### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/cucumber-core.gemspec
+++ b/cucumber-core.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |s|
     'changelog_uri' => 'https://github.com/cucumber/cucumber-ruby-core/blob/master/CHANGELOG.md',
     'documentation_uri' => 'https://www.rubydoc.info/github/cucumber/cucumber-ruby-core',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/cukes',
-    'source_code_uri' => 'https://github.com/cucumber/cucumber-ruby-core'
+    'source_code_uri' => 'https://github.com/cucumber/cucumber-ruby-core',
+    'funding_uri' => 'https://opencollective.com/cucumber'
   }
 
   s.add_dependency 'cucumber-gherkin', '> 27', '< 30'


### PR DESCRIPTION
Similar to https://github.com/cucumber/cucumber-ruby/pull/1768, this PR adds the funding_uri to the gemspec to help increase visibility using the bundle fund command in Bundler.