### PR TITLE
Add Ruby 3.4 to GitHub Actions matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ['3.0', '3.1', '3.2', '3.3']
+        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4']
         include:
           - os: ubuntu-latest
             ruby: jruby
           - os: macos-latest
-            ruby: '3.3'
+            ruby: '3.4'
           - os: windows-latest
-            ruby: '3.3'
+            ruby: '3.4'
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
# Description

This pull request adds Ruby 3.4 to GitHub Actions matrix.

## Type of change

Please delete options that are not relevant.

- Refactoring (improvements to code design or tooling that don't change behaviour)

## Note to other contributors

None.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [x] `bundle exec rubocop` reports no offenses
- [ ] RDoc comments have been updated
- [ ] CHANGELOG.md has been updated
