### PR TITLE
Refactor/remove metaprogramming from event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) for more info on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Changed
+- Refactored the internal base `Event` class to reduce complexity and make it more flexible for future use (No user facing changes)
 
 ## [16.2.0] - 2026-02-06
 ### Changed

--- a/lib/cucumber/core/event.rb
+++ b/lib/cucumber/core/event.rb
@@ -25,16 +25,17 @@ module Cucumber
       end
 
       def to_h
-        instance_variables.to_h { |variable_name| [variable_name[1..].to_sym, instance_variable_get(variable_name)] }
+        instance_variables.to_h do |variable_name|
+          [variable_name.delete('@').to_sym, instance_variable_get(variable_name)]
+        end
       end
 
       def event_id
         self.class.event_id
       end
 
-      # Here just is an array of each method defined as your readers
       def attributes
-        to_h.map { |_k, v| v }
+        instance_variables.map { |var| instance_variable_get(var) }
       end
 
       class << self

--- a/lib/cucumber/core/event.rb
+++ b/lib/cucumber/core/event.rb
@@ -26,16 +26,16 @@ module Cucumber
 
       def to_h
         instance_variables.to_h do |variable_name|
-          [variable_name.delete('@').to_sym, instance_variable_get(variable_name)]
+          [variable_name[1..].to_sym, instance_variable_get(variable_name)]
         end
-      end
-
-      def event_id
-        self.class.event_id
       end
 
       def attributes
         instance_variables.map { |var| instance_variable_get(var) }
+      end
+
+      def event_id
+        self.class.event_id
       end
 
       class << self

--- a/lib/cucumber/core/event.rb
+++ b/lib/cucumber/core/event.rb
@@ -21,19 +21,20 @@ module Cucumber
               instance_variable_set(:"@#{name}", value)
             end
           end
-
-          define_method(:attributes) do
-            events.map { |var| instance_variable_get(:"@#{var}") }
-          end
-
-          define_method(:to_h) do
-            events.zip(attributes).to_h
-          end
-
-          def event_id
-            self.class.event_id
-          end
         end
+      end
+
+      def to_h
+        instance_variables.to_h { |variable_name| [variable_name[1..].to_sym, instance_variable_get(variable_name)] }
+      end
+
+      def event_id
+        self.class.event_id
+      end
+
+      # Here just is an array of each method defined as your readers
+      def attributes
+        to_h.map { |_k, v| v }
       end
 
       class << self

--- a/lib/cucumber/core/events/envelope.rb
+++ b/lib/cucumber/core/events/envelope.rb
@@ -6,7 +6,6 @@ module Cucumber
   module Core
     module Events
       class Envelope < Event.new(:envelope)
-        attr_reader :envelope
       end
     end
   end

--- a/lib/cucumber/core/events/gherkin_source_parsed.rb
+++ b/lib/cucumber/core/events/gherkin_source_parsed.rb
@@ -7,8 +7,7 @@ module Cucumber
     module Events
       # Signals that a gherkin source has been parsed
       class GherkinSourceParsed < Event.new(:gherkin_document)
-        # @return [GherkinDocument] the GherkinDocument Ast Node
-        attr_reader :gherkin_document
+        # @return [GherkinDocument] the GherkinDocument Ast Node that was parsed
       end
     end
   end

--- a/lib/cucumber/core/events/test_case_created.rb
+++ b/lib/cucumber/core/events/test_case_created.rb
@@ -7,11 +7,7 @@ module Cucumber
     module Events
       # Signals that a Test::Case was created from a Pickle
       class TestCaseCreated < Event.new(:test_case, :pickle)
-        # The created test step
-        attr_reader :test_case
-
-        # The source pickle step
-        attr_reader :pickle
+        # The created test step & source pickle
       end
     end
   end

--- a/lib/cucumber/core/events/test_case_finished.rb
+++ b/lib/cucumber/core/events/test_case_finished.rb
@@ -8,10 +8,7 @@ module Cucumber
       # Signals that a {Test::Case} has finished executing
       class TestCaseFinished < Event.new(:test_case, :result)
         # @return [Test::Case] that was executed
-        attr_reader :test_case
-
         # @return [Test::Result] the result of running the {Test::Step}
-        attr_reader :result
       end
     end
   end

--- a/lib/cucumber/core/events/test_case_started.rb
+++ b/lib/cucumber/core/events/test_case_started.rb
@@ -8,7 +8,6 @@ module Cucumber
       # Signals that a {Test::Case} is about to be executed
       class TestCaseStarted < Event.new(:test_case)
         # @return [Test::Case] the test case to be executed
-        attr_reader :test_case
       end
     end
   end

--- a/lib/cucumber/core/events/test_step_created.rb
+++ b/lib/cucumber/core/events/test_step_created.rb
@@ -7,11 +7,7 @@ module Cucumber
     module Events
       # Signals that a Test::Step was created from a PickleStep
       class TestStepCreated < Event.new(:test_step, :pickle_step)
-        # The created test step
-        attr_reader :test_step
-
-        # The source pickle step
-        attr_reader :pickle_step
+        # The created test step & source pickle step
       end
     end
   end

--- a/lib/cucumber/core/events/test_step_finished.rb
+++ b/lib/cucumber/core/events/test_step_finished.rb
@@ -8,10 +8,7 @@ module Cucumber
       # Signals that a {Test::Step} has finished executing
       class TestStepFinished < Event.new(:test_step, :result)
         # @return [Test::Step] the test step that was executed
-        attr_reader :test_step
-
         # @return [Test::Result] the result of running the {Test::Step}
-        attr_reader :result
       end
     end
   end

--- a/lib/cucumber/core/events/test_step_started.rb
+++ b/lib/cucumber/core/events/test_step_started.rb
@@ -8,7 +8,6 @@ module Cucumber
       # Signals that a {Test::Step} is about to be executed
       class TestStepStarted < Event.new(:test_step)
         # @return [Test::Step] the test step to be executed
-        attr_reader :test_step
       end
     end
   end

--- a/spec/cucumber/core_spec.rb
+++ b/spec/cucumber/core_spec.rb
@@ -118,7 +118,8 @@ describe Cucumber::Core do
           observed_events << [:test_case_started, test_case.name]
         end
         event_bus.on(:test_case_finished) do |event|
-          test_case, result = *event.attributes
+          test_case = event.test_case
+          result = event.result
           observed_events << [:test_case_finished, test_case.name, result.to_sym]
         end
         event_bus.on(:test_step_started) do |event|
@@ -126,7 +127,8 @@ describe Cucumber::Core do
           observed_events << [:test_step_started, test_step.text]
         end
         event_bus.on(:test_step_finished) do |event|
-          test_step, result = *event.attributes
+          test_step = event.test_step
+          result = event.result
           observed_events << [:test_step_finished, test_step.text, result.to_sym]
         end
       end


### PR DESCRIPTION
# Description

This removes "most" metaprogramming from the `Event` base class. With a view to removing all of it soon later

This also removes a bunch of duplicated attr readers which are defined by inheriting from `Event`

## Type of change

Please delete options that are not relevant.

- Refactoring (improvements to code design or tooling that don't change behaviour)


## Note to other contributors

If your change may impact future contributors, explain it here, and remember to update README.md and CONTRIBUTING.md accordingly.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] CHANGELOG.md has been updated
