### PR TITLE
Add #to_envelope for gherkin document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 Please visit [cucumber/CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) for more info on how to contribute to Cucumber.
 
 ## [Unreleased]
+### Added
+- Added `#to_envelope` for `Cucumber::Core::Gherkin::Document` ([#329](https://github.com/cucumber/cucumber-ruby-core/pull/329))
+
 ### Changed
 - Refactored the internal base `Event` class to reduce complexity and make it more flexible for future use (No user facing changes)
 

--- a/lib/cucumber/core/gherkin/document.rb
+++ b/lib/cucumber/core/gherkin/document.rb
@@ -7,17 +7,27 @@ module Cucumber
         attr_reader :uri, :body, :language
 
         def initialize(uri, body, language = nil)
-          @uri      = uri
-          @body     = body
+          @uri = uri
+          @body = body
           @language = language || 'en'
+        end
+
+        def ==(other)
+          to_s == other.to_s
         end
 
         def to_s
           body
         end
 
-        def ==(other)
-          to_s == other.to_s
+        def to_envelope
+          Cucumber::Messages::Envelope.new(
+            source: Cucumber::Messages::Source.new(
+              uri: uri,
+              data: body,
+              media_type: 'text/x.cucumber.gherkin+plain'
+            )
+          )
         end
       end
     end


### PR DESCRIPTION
# Description

Adds a `to_envelope` method for Gherkin documents

## Type of change

- New feature (non-breaking change which adds new behaviour)

Please add an entry to the relevant section of CHANGELOG.md as part of this pull request.

## Note to other contributors

If your change may impact future contributors, explain it here, and remember to update README.md and CONTRIBUTING.md accordingly.

# Checklist:

Your PR is ready for review once the following checklist is
complete. You can also add some checks if you want to.

- [ ] Tests have been added for any changes to behaviour of the code
- [ ] New and existing tests are passing locally and on CI
- [ ] `bundle exec rubocop` reports no offenses
- [ ] CHANGELOG.md has been updated
